### PR TITLE
feat(ui): refine weather icon variants and add dev showcase

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -13,6 +13,9 @@ import CurrentWeather from '@/components/CurrentWeather.vue'
 import HourlyForecast from '@/components/HourlyForecast.vue'
 import DailyForecast from '@/components/DailyForecast.vue'
 import RadarMap from '@/components/RadarMap.vue'
+import WeatherIconDemo from '@/components/WeatherIconDemo.vue'
+
+const isDev = import.meta.env.DEV
 
 const locationStore = useLocationStore()
 const weatherStore = useWeatherStore()
@@ -295,6 +298,7 @@ watch(
         <Transition name="content-fade" appear>
           <DailyForecast />
         </Transition>
+        <WeatherIconDemo v-if="isDev" />
       </main>
     </div>
   </div>

--- a/src/components/CurrentWeather.vue
+++ b/src/components/CurrentWeather.vue
@@ -2,7 +2,9 @@
 import { computed } from 'vue'
 import { useWeatherStore } from '@/stores/weather'
 import { usePrecipitationStore } from '@/stores/precipitation'
-import { getWeatherDescription, getWeatherIcon, degreesToCompass } from '@/utils/weatherCodes'
+import { getWeatherDescription, degreesToCompass } from '@/utils/weatherCodes'
+import type { WeatherIntensity } from '@/utils/weatherCodes'
+import WeatherIcon from '@/components/WeatherIcon.vue'
 
 defineEmits<{ (e: 'open-radar'): void }>()
 
@@ -19,15 +21,32 @@ const temperature = computed(() =>
 const feelsLike = computed(() =>
   weather.value !== null ? Math.round(weather.value.apparentTemperature) : null,
 )
-const icon = computed(() =>
-  weather.value !== null ? getWeatherIcon(weather.value.weatherCode) : '',
-)
 const description = computed(() =>
   weather.value !== null ? getWeatherDescription(weather.value.weatherCode) : '',
 )
 const windCompass = computed(() =>
   weather.value !== null ? degreesToCompass(weather.value.windDirection) : '',
 )
+
+// ── Current-hour icon intensity ──────────────────────────────────────────────
+
+/**
+ * Intensity hint for the hero WeatherIcon derived from the current-hour
+ * precipitation value (mm). Uses the same rate-based thresholds as the
+ * hourly forecast view so the two are visually consistent.
+ *
+ * Falls back to `undefined` when:
+ *   - no weather data is loaded yet
+ *   - `precipitation` is null (older persisted cache shape without this field)
+ *   - precipitation is 0 (dry — no intensity override needed)
+ */
+const currentWeatherIntensity = computed<WeatherIntensity | undefined>(() => {
+  const precip = weather.value?.precipitation ?? null
+  if (precip === null || precip === 0) return undefined
+  if (precip >= 7.5) return 'heavy'
+  if (precip >= 0.5) return 'moderate'
+  return 'light'
+})
 
 // ── Precipitation helpers ────────────────────────────────────────────────────
 
@@ -64,14 +83,21 @@ const rainIntensityLabel = computed<string>(() => {
   return 'Heavy rain'
 })
 
-/** Icon for the current/upcoming rain intensity */
-const rainIntensityIcon = computed<string>(() => {
+/** WMO code to show in the rain alert icon (clear-sky or current weather code) */
+const rainAlertCode = computed<number>(() => {
   const idx = precipStore.entries.findIndex((e) => e.mmPerHour >= 0.1)
-  if (idx === -1) return '☀️'
+  if (idx === -1) return 0 // clear sky
+  return weather.value?.weatherCode ?? 63 // fallback to plain rain
+})
+
+/** Intensity hint for the rain alert icon */
+const rainAlertIntensity = computed<'light' | 'moderate' | 'heavy' | undefined>(() => {
+  const idx = precipStore.entries.findIndex((e) => e.mmPerHour >= 0.1)
+  if (idx === -1) return undefined
   const mm = precipStore.entries[idx].mmPerHour
-  if (mm < 0.5) return '🌦️'
-  if (mm <= 7.5) return '🌧️'
-  return '⛈️'
+  if (mm < 0.5) return 'light'
+  if (mm <= 7.5) return 'moderate'
+  return 'heavy'
 })
 
 /** Show every Nth label to avoid crowding (Buienradar gives 24 × 5-min entries) */
@@ -190,12 +216,12 @@ const gridLines = computed(() => {
         </div>
 
         <!-- Weather icon (large) -->
-        <span
-          class="select-none text-6xl drop-shadow-md transition-all duration-300"
-          aria-hidden="true"
-        >
-          {{ icon }}
-        </span>
+        <WeatherIcon
+          :code="weather.weatherCode"
+          :intensity="currentWeatherIntensity"
+          :size="64"
+          class="drop-shadow-md transition-all duration-300"
+        />
       </div>
 
       <!-- Description -->
@@ -344,9 +370,11 @@ const gridLines = computed(() => {
           @click="$emit('open-radar')"
         >
           <!-- Icon -->
-          <span class="text-xl leading-none">
-          {{ rainIntensityIcon }}
-          </span>
+          <WeatherIcon
+            :code="rainAlertCode"
+            :intensity="rainAlertIntensity"
+            :size="24"
+          />
 
           <!-- Message -->
           <span v-if="alertStyle === 'rain'">{{ rainIntensityLabel }} — falling now</span>

--- a/src/components/CurrentWeather.vue
+++ b/src/components/CurrentWeather.vue
@@ -32,8 +32,15 @@ const windCompass = computed(() =>
 
 /**
  * Intensity hint for the hero WeatherIcon derived from the current-hour
- * precipitation value (mm). Uses the same rate-based thresholds as the
+ * precipitation value (mm/h). Uses the same rate-based thresholds as the
  * hourly forecast view so the two are visually consistent.
+ *
+ * Thresholds (mm/h):
+ *   dry:      0
+ *   drizzle:  > 0  to < 0.5  → 'light'  (routes to drizzle-light SVG via WMO code)
+ *   light:    0.5  to  2.5   → 'light'
+ *   moderate: 2.6  to  7.6   → 'moderate'
+ *   heavy:    > 7.6          → 'heavy'
  *
  * Falls back to `undefined` when:
  *   - no weather data is loaded yet
@@ -43,9 +50,9 @@ const windCompass = computed(() =>
 const currentWeatherIntensity = computed<WeatherIntensity | undefined>(() => {
   const precip = weather.value?.precipitation ?? null
   if (precip === null || precip === 0) return undefined
-  if (precip >= 7.5) return 'heavy'
+  if (precip > 7.6) return 'heavy'
   if (precip >= 0.5) return 'moderate'
-  return 'light'
+  return 'light' // covers drizzle (> 0 to < 0.5) and light (0.5 to 2.5, handled above)
 })
 
 // ── Precipitation helpers ────────────────────────────────────────────────────
@@ -66,10 +73,10 @@ function barHeightPercent(mmPerHour: number): number {
 /** Color class for a precipitation bar based on intensity */
 function barColorClass(mmPerHour: number): string {
   if (mmPerHour <= 0) return 'bg-slate-200 dark:bg-white/10'
-  if (mmPerHour < 0.5) return 'bg-blue-300/60 dark:bg-blue-300/50'
-  if (mmPerHour <= 2.5) return 'bg-blue-400/80 dark:bg-blue-400/70'
-  if (mmPerHour <= 7.5) return 'bg-blue-600/85 dark:bg-blue-500/80'
-  return 'bg-purple-500/90 dark:bg-purple-400/85'
+  if (mmPerHour < 0.5) return 'bg-blue-300/60 dark:bg-blue-300/50'   // drizzle
+  if (mmPerHour <= 2.5) return 'bg-blue-400/80 dark:bg-blue-400/70'  // light
+  if (mmPerHour <= 7.6) return 'bg-blue-600/85 dark:bg-blue-500/80'  // moderate
+  return 'bg-purple-500/90 dark:bg-purple-400/85'                     // heavy
 }
 
 /** Describes the intensity of the first upcoming rain */
@@ -77,10 +84,10 @@ const rainIntensityLabel = computed<string>(() => {
   const idx = precipStore.entries.findIndex((e) => e.mmPerHour >= 0.1)
   if (idx === -1) return ''
   const mm = precipStore.entries[idx].mmPerHour
-  if (mm < 0.5) return 'Light drizzle'
-  if (mm <= 2.5) return 'Light rain'
-  if (mm <= 7.5) return 'Moderate rain'
-  return 'Heavy rain'
+  if (mm < 0.5) return 'Light drizzle'   // > 0 to < 0.5 mm/h
+  if (mm <= 2.5) return 'Light rain'     // 0.5 to 2.5 mm/h
+  if (mm <= 7.6) return 'Moderate rain'  // 2.6 to 7.6 mm/h
+  return 'Heavy rain'                     // > 7.6 mm/h
 })
 
 /** WMO code to show in the rain alert icon (clear-sky or current weather code) */
@@ -95,9 +102,10 @@ const rainAlertIntensity = computed<'light' | 'moderate' | 'heavy' | undefined>(
   const idx = precipStore.entries.findIndex((e) => e.mmPerHour >= 0.1)
   if (idx === -1) return undefined
   const mm = precipStore.entries[idx].mmPerHour
-  if (mm < 0.5) return 'light'
-  if (mm <= 7.5) return 'moderate'
-  return 'heavy'
+  if (mm < 0.5) return 'light'    // drizzle (> 0 to < 0.5 mm/h)
+  if (mm <= 2.5) return 'light'   // light (0.5 to 2.5 mm/h)
+  if (mm <= 7.6) return 'moderate' // moderate (2.6 to 7.6 mm/h)
+  return 'heavy'                    // heavy (> 7.6 mm/h)
 })
 
 /** Show every Nth label to avoid crowding (Buienradar gives 24 × 5-min entries) */
@@ -119,7 +127,7 @@ const chartScale = computed(() => Math.max(precipStore.maxIntensity, MIN_SCALE_M
 
 const gridLines = computed(() => {
   const max = chartScale.value
-  const thresholds = [0.5, 2.5, 7.5]
+  const thresholds = [0.5, 2.5, 7.6]
   const visible = thresholds.filter(t => {
     const pct = (t / max) * 100
     return pct >= 5 && pct <= 95
@@ -316,7 +324,7 @@ const gridLines = computed(() => {
                 class="relative flex-1 rounded-t transition-all duration-300"
                 :class="barColorClass(entry.mmPerHour)"
                 :style="{ height: `${barHeightPercent(entry.mmPerHour)}%` }"
-                :title="`${entry.time} — ${entry.mmPerHour > 0 ? entry.mmPerHour.toFixed(2) + ' mm/h (' + (entry.mmPerHour < 0.5 ? 'drizzle' : entry.mmPerHour <= 2.5 ? 'light' : entry.mmPerHour <= 7.5 ? 'moderate' : 'heavy') + ')' : 'dry'}`"
+                :title="`${entry.time} — ${entry.mmPerHour > 0 ? entry.mmPerHour.toFixed(2) + ' mm/h (' + (entry.mmPerHour < 0.5 ? 'drizzle' : entry.mmPerHour <= 2.5 ? 'light' : entry.mmPerHour <= 7.6 ? 'moderate' : 'heavy') + ')' : 'dry'}`"
                 :aria-label="`${entry.time}: ${entry.mmPerHour.toFixed(2)} mm/h`"
               >
                 <!-- Highlight the first rainy bar -->

--- a/src/components/DailyForecast.vue
+++ b/src/components/DailyForecast.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import { useWeatherStore } from '@/stores/weather'
-import { getWeatherIcon } from '@/utils/weatherCodes'
+import WeatherIcon from '@/components/WeatherIcon.vue'
+import type { WeatherIntensity } from '@/utils/weatherCodes'
 
 const weatherStore = useWeatherStore()
 
@@ -22,11 +23,43 @@ interface DayRow {
   date: string
   dayName: string
   dateLabel: string
-  icon: string
+  code: number
   tempMax: number
   tempMin: number
   precipProb: number
   precipSum: number
+  /** Hours with precipitation ≥ 0.1 mm; null when field is absent from older cache shapes */
+  precipHours: number | null
+}
+
+/**
+ * Derive a daily precipitation intensity bucket using wet-duration as the
+ * primary signal and total-sum as a fallback for older cache shapes where
+ * `precipitationHours` is absent (null).
+ *
+ * Wet-duration buckets (hours with ≥ 0.1 mm):
+ *   0        → undefined (dry)
+ *   < 2 h    → 'light'   (occasional showers or brief drizzle)
+ *   < 6 h    → 'moderate'(several hours of rain across the day)
+ *   ≥ 6 h    → 'heavy'   (persistent / all-day rain)
+ *
+ * Sum-only fallback (mm/day, only when precipitationHours is null):
+ *   > 0      → 'light'
+ *   ≥ 5      → 'moderate'
+ *   ≥ 20     → 'heavy'
+ */
+function dailyIntensity(precipHours: number | null, precipSum: number): WeatherIntensity | undefined {
+  if (precipHours !== null) {
+    if (precipHours === 0) return undefined
+    if (precipHours < 2) return 'light'
+    if (precipHours < 6) return 'moderate'
+    return 'heavy'
+  }
+  // Fallback: sum-based (crude but safe for legacy cache)
+  if (precipSum <= 0) return undefined
+  if (precipSum >= 20) return 'heavy'
+  if (precipSum >= 5) return 'moderate'
+  return 'light'
 }
 
 const days = computed<DayRow[]>(() => {
@@ -37,11 +70,13 @@ const days = computed<DayRow[]>(() => {
     date,
     dayName: formatDayName(date, i),
     dateLabel: formatDate(date),
-    icon: getWeatherIcon(f.weatherCode[i] ?? 0),
+    code: f.weatherCode[i] ?? 0,
     tempMax: Math.round(f.temperatureMax[i] ?? 0),
     tempMin: Math.round(f.temperatureMin[i] ?? 0),
     precipProb: Math.round(f.precipitationProbabilityMax[i] ?? 0),
     precipSum: Math.round((f.precipitationSum[i] ?? 0) * 10) / 10,
+    // precipitationHours is null when absent from older persisted cache shapes
+    precipHours: f.precipitationHours !== null ? (f.precipitationHours[i] ?? null) : null,
   }))
 })
 
@@ -117,9 +152,11 @@ const error = computed(() => weatherStore.error)
         </div>
 
         <!-- Weather icon -->
-        <span class="text-xl leading-none" :title="day.icon" aria-hidden="true">
-          {{ day.icon }}
-        </span>
+        <WeatherIcon
+          :code="day.code"
+          :intensity="dailyIntensity(day.precipHours, day.precipSum)"
+          :size="28"
+        />
 
         <!-- Precipitation info -->
         <div class="flex items-center gap-2 text-xs text-blue-600 dark:text-blue-200">

--- a/src/components/DailyForecast.vue
+++ b/src/components/DailyForecast.vue
@@ -33,33 +33,60 @@ interface DayRow {
 }
 
 /**
- * Derive a daily precipitation intensity bucket using wet-duration as the
- * primary signal and total-sum as a fallback for older cache shapes where
- * `precipitationHours` is absent (null).
+ * Derive a daily precipitation intensity bucket.
  *
- * Wet-duration buckets (hours with ≥ 0.1 mm):
- *   0        → undefined (dry)
- *   < 2 h    → 'light'   (occasional showers or brief drizzle)
- *   < 6 h    → 'moderate'(several hours of rain across the day)
- *   ≥ 6 h    → 'heavy'   (persistent / all-day rain)
+ * Primary path — wet-hour average (requires `precipitationHours` ≥ 1):
+ *   avg = precipitationSum / precipitationHours  (mm/h across wet hours)
  *
- * Sum-only fallback (mm/day, only when precipitationHours is null):
- *   > 0      → 'light'
- *   ≥ 5      → 'moderate'
- *   ≥ 20     → 'heavy'
+ *   avg buckets:
+ *     dry:      0 mm or 0 wet hours   → undefined
+ *     drizzle:  > 0   to < 0.5 mm/h  → 'light'
+ *     light:    0.5   to  2.5  mm/h  → 'light'
+ *     moderate: 2.6   to  7.6  mm/h  → 'moderate'
+ *     heavy:    > 7.6 mm/h           → 'heavy'
+ *
+ *   Daily overrides (applied after the avg bucket, can only raise intensity):
+ *     precipitationSum ≥ 35 mm/day                              → 'heavy'
+ *     precipitationSum ≥ 20 mm/day                              → at least 'moderate'
+ *     precipitationHours ≥ 8 and precipitationSum ≥ 15 mm/day  → 'heavy'
+ *
+ * Fallback — sum-only (when `precipitationHours` is null, older cache shapes):
+ *   dry:      0 mm              → undefined
+ *   drizzle:  > 0  to < 2.5    → 'light'
+ *   light:    2.5  to  7.5 mm  → 'light'
+ *   moderate: 7.6  to 20   mm  → 'moderate'
+ *   heavy:    > 20 mm          → 'heavy'
  */
 function dailyIntensity(precipHours: number | null, precipSum: number): WeatherIntensity | undefined {
   if (precipHours !== null) {
-    if (precipHours === 0) return undefined
-    if (precipHours < 2) return 'light'
-    if (precipHours < 6) return 'moderate'
-    return 'heavy'
+    // Primary: avg mm/h over wet hours
+    if (precipHours === 0 || precipSum <= 0) return undefined
+    const avg = precipSum / precipHours
+
+    let intensity: WeatherIntensity
+    if (avg > 7.6) {
+      intensity = 'heavy'
+    } else if (avg >= 0.5) {
+      // covers light (0.5–2.5) and moderate (2.6–7.6)
+      intensity = avg <= 2.5 ? 'light' : 'moderate'
+    } else {
+      intensity = 'light' // drizzle: > 0 to < 0.5 avg mm/h
+    }
+
+    // Daily overrides — can only raise, never lower
+    if (precipSum >= 35) return 'heavy'
+    if (precipHours >= 8 && precipSum >= 15) return 'heavy'
+    if (precipSum >= 20 && intensity !== 'heavy') return 'moderate'
+
+    return intensity
   }
-  // Fallback: sum-based (crude but safe for legacy cache)
+
+  // Fallback: sum-based for legacy cache shapes where precipitationHours is null
   if (precipSum <= 0) return undefined
-  if (precipSum >= 20) return 'heavy'
-  if (precipSum >= 5) return 'moderate'
-  return 'light'
+  if (precipSum > 20) return 'heavy'
+  if (precipSum >= 7.6) return 'moderate'
+  if (precipSum >= 2.5) return 'light'
+  return 'light' // drizzle: > 0 to < 2.5 mm/day
 }
 
 const days = computed<DayRow[]>(() => {

--- a/src/components/HourlyForecast.vue
+++ b/src/components/HourlyForecast.vue
@@ -107,7 +107,7 @@ const hourlyCards = computed<HourlyCard[]>(() => {
           <!-- Weather icon -->
           <WeatherIcon
             :code="card.code"
-            :intensity="card.precip >= 7.5 ? 'heavy' : card.precip >= 0.5 ? 'moderate' : card.precip > 0 ? 'light' : undefined"
+            :intensity="card.precip > 7.6 ? 'heavy' : card.precip >= 0.5 ? 'moderate' : card.precip > 0 ? 'light' : undefined"
             :size="28"
           />
           <!-- Temperature -->

--- a/src/components/HourlyForecast.vue
+++ b/src/components/HourlyForecast.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import { useWeatherStore } from '@/stores/weather'
-import { getWeatherIcon } from '@/utils/weatherCodes'
+import WeatherIcon from '@/components/WeatherIcon.vue'
 
 const weatherStore = useWeatherStore()
 
@@ -17,7 +17,7 @@ function formatHour(isoTime: string): string {
 
 interface HourlyCard {
   time: string
-  icon: string
+  code: number
   temp: number
   precip: number
   precipProb: number
@@ -27,7 +27,7 @@ const hourlyCards = computed<HourlyCard[]>(() => {
   if (!forecast.value) return []
   return forecast.value.time.map((t, i) => ({
     time: formatHour(t),
-    icon: getWeatherIcon(forecast.value!.weatherCode[i] ?? 0),
+    code: forecast.value!.weatherCode[i] ?? 0,
     temp: Math.round(forecast.value!.temperature[i] ?? 0),
     precip: forecast.value!.precipitation[i] ?? 0,
     precipProb: forecast.value!.precipitationProbability[i] ?? 0,
@@ -105,7 +105,11 @@ const hourlyCards = computed<HourlyCard[]>(() => {
           <!-- Time -->
           <span class="text-xs text-slate-500 dark:text-white/60">{{ card.time }}</span>
           <!-- Weather icon -->
-          <span class="text-xl" aria-hidden="true">{{ card.icon }}</span>
+          <WeatherIcon
+            :code="card.code"
+            :intensity="card.precip >= 7.5 ? 'heavy' : card.precip >= 0.5 ? 'moderate' : card.precip > 0 ? 'light' : undefined"
+            :size="28"
+          />
           <!-- Temperature -->
           <span class="text-sm font-semibold text-slate-800 dark:text-white">{{ card.temp }}°</span>
           <!-- Precipitation mm (only if > 0) -->

--- a/src/components/WeatherIcon.vue
+++ b/src/components/WeatherIcon.vue
@@ -1,0 +1,69 @@
+<script setup lang="ts">
+/**
+ * WeatherIcon
+ *
+ * Renders an inline SVG weather icon for a WMO weather code with an optional
+ * intensity variant. This is the single shared primitive for current, hourly,
+ * and daily weather views.
+ *
+ * Props
+ * ─────
+ * code        (required) — WMO weather code (number)
+ * intensity   (optional) — 'light' | 'moderate' | 'heavy'
+ *             When provided, codes that support intensity differentiation
+ *             (rain, drizzle, snow, showers) may return a distinct SVG variant.
+ *             Omit to use the code's natural icon.
+ * size        (optional) — pixel size for the SVG (width & height). Defaults to 32.
+ * label       (optional) — Accessible label string. When omitted the element
+ *             is marked aria-hidden="true" (decorative).
+ *
+ * Usage examples
+ * ──────────────
+ * <!-- Plain — code only, decorative -->
+ * <WeatherIcon :code="weatherCode" />
+ *
+ * <!-- With intensity hint -->
+ * <WeatherIcon :code="63" intensity="heavy" />
+ *
+ * <!-- Custom size + accessible label -->
+ * <WeatherIcon :code="0" :size="64" label="Clear sky" />
+ */
+import { computed } from 'vue'
+import { getWeatherSvgIcon, getWeatherDescription } from '@/utils/weatherCodes'
+import type { WeatherIntensity } from '@/utils/weatherCodes'
+
+const props = withDefaults(
+  defineProps<{
+    /** WMO weather code */
+    code: number
+    /** Optional precipitation / severity intensity hint */
+    intensity?: WeatherIntensity
+    /** SVG size in pixels (width & height, default: 32) */
+    size?: number
+    /** Accessible label — omit for decorative icons */
+    label?: string
+  }>(),
+  {
+    intensity: undefined,
+    size: 32,
+    label: undefined,
+  },
+)
+
+const svgPath = computed(() => getWeatherSvgIcon(props.code, props.intensity))
+const ariaLabel = computed(() => props.label ?? getWeatherDescription(props.code))
+const isDecorative = computed(() => props.label === undefined)
+</script>
+
+<template>
+  <svg
+    :width="size"
+    :height="size"
+    viewBox="0 0 64 64"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+    class="select-none shrink-0"
+    v-bind="isDecorative ? { 'aria-hidden': 'true' } : { role: 'img', 'aria-label': ariaLabel }"
+    v-html="svgPath"
+  />
+</template>

--- a/src/components/WeatherIconDemo.vue
+++ b/src/components/WeatherIconDemo.vue
@@ -1,0 +1,158 @@
+<script setup lang="ts">
+/**
+ * WeatherIconDemo
+ *
+ * Development-only showcase of all weather icon variants available in the
+ * icon system. Rendered at the bottom of App.vue only when
+ * `import.meta.env.DEV` is true — stripped from production builds entirely.
+ */
+import WeatherIcon from '@/components/WeatherIcon.vue'
+import type { WeatherIntensity } from '@/utils/weatherCodes'
+
+interface IconEntry {
+  /** WMO code to pass to WeatherIcon */
+  code: number
+  /** Human-readable label shown under the icon */
+  label: string
+  /** Optional intensity override */
+  intensity?: WeatherIntensity
+}
+
+interface IconGroup {
+  title: string
+  icons: IconEntry[]
+}
+
+const groups: IconGroup[] = [
+  {
+    title: 'Sky conditions',
+    icons: [
+      { code: 0,  label: 'Clear sky' },
+      { code: 1,  label: 'Mainly clear' },
+      { code: 2,  label: 'Partly cloudy' },
+      { code: 3,  label: 'Overcast' },
+      { code: 45, label: 'Fog' },
+      { code: 48, label: 'Icy fog' },
+    ],
+  },
+  {
+    title: 'Drizzle — light → moderate → heavy',
+    icons: [
+      { code: 51, label: 'Drizzle',  intensity: 'light' },
+      { code: 53, label: 'Drizzle',  intensity: 'moderate' },
+      { code: 55, label: 'Drizzle',  intensity: 'heavy' },
+    ],
+  },
+  {
+    title: 'Rain — light → moderate → heavy',
+    icons: [
+      { code: 61, label: 'Rain',  intensity: 'light' },
+      { code: 63, label: 'Rain',  intensity: 'moderate' },
+      { code: 65, label: 'Rain',  intensity: 'heavy' },
+    ],
+  },
+  {
+    title: 'Freezing precipitation',
+    icons: [
+      { code: 56, label: 'Freezing drizzle (light)' },
+      { code: 57, label: 'Freezing drizzle (heavy)' },
+      { code: 66, label: 'Freezing rain (light)' },
+      { code: 67, label: 'Freezing rain (heavy)' },
+    ],
+  },
+  {
+    title: 'Rain showers — light → moderate → heavy',
+    icons: [
+      { code: 80, label: 'Showers',  intensity: 'light' },
+      { code: 81, label: 'Showers',  intensity: 'moderate' },
+      { code: 82, label: 'Showers',  intensity: 'heavy' },
+    ],
+  },
+  {
+    title: 'Snow — light → moderate → heavy',
+    icons: [
+      { code: 71, label: 'Snow',  intensity: 'light' },
+      { code: 73, label: 'Snow',  intensity: 'moderate' },
+      { code: 75, label: 'Snow',  intensity: 'heavy' },
+      { code: 77, label: 'Snow grains' },
+    ],
+  },
+  {
+    title: 'Snow showers — light → heavy',
+    icons: [
+      { code: 85, label: 'Snow showers',  intensity: 'light' },
+      { code: 86, label: 'Snow showers',  intensity: 'heavy' },
+    ],
+  },
+  {
+    title: 'Thunderstorms',
+    icons: [
+      { code: 95, label: 'Thunderstorm' },
+      { code: 96, label: 'Thunder + hail' },
+      { code: 99, label: 'Thunder + heavy hail' },
+    ],
+  },
+  {
+    title: 'Intensity cross-reference — WMO code 63 (Rain)',
+    icons: [
+      { code: 63, label: 'No hint' },
+      { code: 63, label: 'Light',    intensity: 'light' },
+      { code: 63, label: 'Moderate', intensity: 'moderate' },
+      { code: 63, label: 'Heavy',    intensity: 'heavy' },
+    ],
+  },
+]
+</script>
+
+<template>
+  <section
+    class="mt-2 rounded-2xl border border-dashed border-amber-400/60 bg-amber-50/60 px-4 py-5 dark:border-amber-400/30 dark:bg-amber-900/10"
+    aria-label="Weather icon showcase (dev only)"
+  >
+    <!-- Header -->
+    <div class="mb-4 flex items-center gap-2">
+      <span class="rounded bg-amber-400 px-1.5 py-0.5 text-xs font-bold uppercase tracking-wide text-amber-900">
+        DEV
+      </span>
+      <h2 class="text-sm font-semibold text-slate-700 dark:text-slate-200">
+        Weather icon showcase
+      </h2>
+      <span class="text-xs text-slate-500 dark:text-slate-400">(not shown in production)</span>
+    </div>
+
+    <!-- Groups -->
+    <div class="flex flex-col gap-6">
+      <div
+        v-for="group in groups"
+        :key="group.title"
+      >
+        <p class="mb-2 text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
+          {{ group.title }}
+        </p>
+        <div class="flex flex-wrap gap-3">
+          <div
+            v-for="(entry, idx) in group.icons"
+            :key="idx"
+            class="flex flex-col items-center gap-1.5 rounded-xl bg-white/70 px-3 py-2.5 shadow-sm dark:bg-white/5"
+          >
+            <WeatherIcon
+              :code="entry.code"
+              :intensity="entry.intensity"
+              :size="40"
+              :label="entry.label"
+            />
+            <span class="max-w-[80px] text-center text-[10px] leading-tight text-slate-600 dark:text-slate-300">
+              {{ entry.label }}
+            </span>
+            <span
+              v-if="entry.intensity"
+              class="rounded-full bg-blue-100 px-1.5 py-0.5 text-[9px] font-medium text-blue-700 dark:bg-blue-900/40 dark:text-blue-300"
+            >
+              {{ entry.intensity }}
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+</template>

--- a/src/services/weatherService.ts
+++ b/src/services/weatherService.ts
@@ -85,7 +85,7 @@ export async function fetchCurrentWeather(lat: number, lon: number): Promise<Cur
     latitude: String(lat),
     longitude: String(lon),
     current:
-      'temperature_2m,relative_humidity_2m,apparent_temperature,weather_code,wind_speed_10m,wind_direction_10m',
+      'temperature_2m,relative_humidity_2m,apparent_temperature,weather_code,wind_speed_10m,wind_direction_10m,precipitation',
     timezone: 'auto',
   })
 
@@ -107,6 +107,7 @@ export async function fetchCurrentWeather(lat: number, lon: number): Promise<Cur
     windSpeed: c.wind_speed_10m,
     windDirection: c.wind_direction_10m,
     time: c.time,
+    precipitation: c.precipitation ?? null,
   }
 }
 
@@ -149,7 +150,7 @@ export async function fetchDailyForecast(lat: number, lon: number): Promise<Dail
     latitude: String(lat),
     longitude: String(lon),
     daily:
-      'weather_code,temperature_2m_max,temperature_2m_min,precipitation_sum,precipitation_probability_max',
+      'weather_code,temperature_2m_max,temperature_2m_min,precipitation_sum,precipitation_probability_max,precipitation_hours',
     timezone: 'auto',
   })
 
@@ -170,5 +171,6 @@ export async function fetchDailyForecast(lat: number, lon: number): Promise<Dail
     temperatureMin: d.temperature_2m_min,
     precipitationSum: d.precipitation_sum,
     precipitationProbabilityMax: d.precipitation_probability_max,
+    precipitationHours: d.precipitation_hours ?? null,
   }
 }

--- a/src/stores/weather.ts
+++ b/src/stores/weather.ts
@@ -20,7 +20,19 @@ function loadFromStorage(): WeatherCache | null {
   try {
     const raw = localStorage.getItem(STORAGE_KEY)
     if (!raw) return null
-    return JSON.parse(raw) as WeatherCache
+    const parsed = JSON.parse(raw) as WeatherCache
+
+    // Backward-compatible normalization: older cached shapes may be missing
+    // fields added after the initial release. Coerce undefined → null so the
+    // rest of the app always receives a known type (number | null).
+    if (parsed.currentWeather) {
+      parsed.currentWeather.precipitation = parsed.currentWeather.precipitation ?? null
+    }
+    if (parsed.dailyForecast) {
+      parsed.dailyForecast.precipitationHours = parsed.dailyForecast.precipitationHours ?? null
+    }
+
+    return parsed
   } catch {
     return null
   }

--- a/src/types/weather.ts
+++ b/src/types/weather.ts
@@ -69,6 +69,8 @@ export interface OpenMeteoCurrentWeatherResponse {
     weather_code: string
     wind_speed_10m: string
     wind_direction_10m: string
+    /** Present only when precipitation is requested */
+    precipitation?: string
   }
   current: {
     time: string
@@ -78,6 +80,8 @@ export interface OpenMeteoCurrentWeatherResponse {
     weather_code: number
     wind_speed_10m: number
     wind_direction_10m: number
+    /** Precipitation amount in mm for the current hour; absent in older cached shapes */
+    precipitation?: number
   }
 }
 
@@ -91,6 +95,11 @@ export interface CurrentWeather {
   windDirection: number
   /** ISO 8601 timestamp returned by Open-Meteo */
   time: string
+  /**
+   * Precipitation amount for the current hour in mm.
+   * Null when the value is missing (e.g. older persisted cache shapes).
+   */
+  precipitation: number | null
 }
 
 // ---------------------------------------------------------------------------
@@ -140,6 +149,11 @@ export interface DailyForecast {
   temperatureMin: number[]
   precipitationSum: number[]
   precipitationProbabilityMax: number[]
+  /**
+   * Number of hours with precipitation per day (≥ 0.1 mm threshold).
+   * Null when the value is missing (e.g. older persisted cache shapes).
+   */
+  precipitationHours: number[] | null
 }
 
 /** Raw response shape from Open-Meteo /v1/forecast (daily fields only) */
@@ -155,6 +169,8 @@ export interface OpenMeteoDailyResponse {
     temperature_2m_min: string
     precipitation_sum: string
     precipitation_probability_max: string
+    /** Present only when precipitation_hours is requested */
+    precipitation_hours?: string
   }
   daily: {
     time: string[]
@@ -163,6 +179,8 @@ export interface OpenMeteoDailyResponse {
     temperature_2m_min: number[]
     precipitation_sum: number[]
     precipitation_probability_max: number[]
+    /** Absent in older cached shapes */
+    precipitation_hours?: number[]
   }
 }
 

--- a/src/utils/weatherCodes.ts
+++ b/src/utils/weatherCodes.ts
@@ -3,43 +3,341 @@
  * https://open-meteo.com/en/docs#weathervariables
  */
 
+// ---------------------------------------------------------------------------
+// Intensity variant type
+// ---------------------------------------------------------------------------
+
+/**
+ * Optional precipitation / severity intensity hint.
+ *
+ * - `'light'`    – drizzle, light rain/snow, gentle showers
+ * - `'moderate'` – typical rain/snow, normal showers
+ * - `'heavy'`    – heavy rain/snow, violent showers, hail storms
+ *
+ * When omitted the icon is derived purely from the WMO weather code
+ * (same behaviour as the legacy `getWeatherIcon` function).
+ */
+export type WeatherIntensity = 'light' | 'moderate' | 'heavy'
+
 interface WeatherCodeMeta {
   description: string
+  /** Emoji fallback (kept for non-SVG usage and legacy callers) */
   icon: string
+  /** SVG icon key for the WeatherIcon component */
+  svgKey: SvgIconKey
 }
+
+// ---------------------------------------------------------------------------
+// SVG icon key union
+// ---------------------------------------------------------------------------
+
+/**
+ * All SVG icon variants available in the icon system.
+ *
+ * Precipitation-related states have distinct variants per intensity level;
+ * non-precipitation states have a single variant.
+ */
+export type SvgIconKey =
+  | 'clear-day'
+  | 'mostly-clear'
+  | 'partly-cloudy'
+  | 'overcast'
+  | 'fog'
+  | 'drizzle-light'
+  | 'drizzle-moderate'
+  | 'drizzle-heavy'
+  | 'rain-light'
+  | 'rain-moderate'
+  | 'rain-heavy'
+  | 'showers-light'
+  | 'showers-moderate'
+  | 'showers-heavy'
+  | 'freezing-rain'
+  | 'snow-light'
+  | 'snow-moderate'
+  | 'snow-heavy'
+  | 'snow-showers-light'
+  | 'snow-showers-heavy'
+  | 'thunderstorm'
+  | 'thunderstorm-hail'
+  | 'unknown'
+
+// ---------------------------------------------------------------------------
+// SVG path definitions (inline, viewBox 0 0 64 64)
+// ---------------------------------------------------------------------------
+
+/**
+ * Inline SVG markup strings (inner content of <svg viewBox="0 0 64 64">).
+ * All icons use currentColor where appropriate and work in both light/dark mode.
+ *
+ * Colour tokens used:
+ *   - Sun:         #FBBF24 (amber-400)
+ *   - Cloud body:  #CBD5E1 (slate-300) / #94A3B8 (slate-400) for shadow
+ *   - Rain drops:  #60A5FA (blue-400)
+ *   - Snow:        #BAE6FD (sky-200)
+ *   - Lightning:   #FDE68A (amber-200)
+ *   - Hail:        #E0F2FE (sky-100) with #7DD3FC border
+ *   - Fog lines:   #94A3B8 (slate-400)
+ *   - Freeze:      #BAE6FD (sky-200)
+ *   - Dark cloud:  #64748B (slate-500) — used for heavy/storm variants
+ */
+export const SVG_ICONS: Record<SvgIconKey, string> = {
+  // ── Clear ──────────────────────────────────────────────────────────────────
+  'clear-day': `
+    <circle cx="32" cy="32" r="13" fill="#FBBF24"/>
+    <g stroke="#FBBF24" stroke-width="3" stroke-linecap="round">
+      <line x1="32" y1="7"  x2="32" y2="13"/>
+      <line x1="32" y1="51" x2="32" y2="57"/>
+      <line x1="7"  y1="32" x2="13" y2="32"/>
+      <line x1="51" y1="32" x2="57" y2="32"/>
+      <line x1="14" y1="14" x2="18" y2="18"/>
+      <line x1="46" y1="46" x2="50" y2="50"/>
+      <line x1="50" y1="14" x2="46" y2="18"/>
+      <line x1="18" y1="46" x2="14" y2="50"/>
+    </g>`,
+
+  // ── Mainly clear ───────────────────────────────────────────────────────────
+  'mostly-clear': `
+    <circle cx="26" cy="26" r="10" fill="#FBBF24"/>
+    <g stroke="#FBBF24" stroke-width="2.5" stroke-linecap="round">
+      <line x1="26" y1="6"  x2="26" y2="11"/>
+      <line x1="26" y1="41" x2="26" y2="46"/>
+      <line x1="6"  y1="26" x2="11" y2="26"/>
+      <line x1="41" y1="26" x2="46" y2="26"/>
+      <line x1="12" y1="12" x2="15" y2="15"/>
+      <line x1="37" y1="37" x2="40" y2="40"/>
+      <line x1="40" y1="12" x2="37" y2="15"/>
+      <line x1="15" y1="37" x2="12" y2="40"/>
+    </g>
+    <path d="M36 40 Q36 30 44 30 Q42 24 36 24 Q34 18 27 20 Q22 14 16 20 Q10 20 10 28 Q10 40 20 40 Z" fill="#CBD5E1"/>`,
+
+  // ── Partly cloudy ──────────────────────────────────────────────────────────
+  'partly-cloudy': `
+    <circle cx="24" cy="22" r="10" fill="#FBBF24"/>
+    <g stroke="#FBBF24" stroke-width="2.5" stroke-linecap="round">
+      <line x1="24" y1="4"  x2="24" y2="9"/>
+      <line x1="4"  y1="22" x2="9"  y2="22"/>
+      <line x1="10" y1="8"  x2="14" y2="12"/>
+      <line x1="38" y1="8"  x2="34" y2="12"/>
+    </g>
+    <path d="M42 46 Q42 34 51 34 Q49 27 42 27 Q40 20 32 22 Q26 15 19 22 Q12 22 12 31 Q12 46 24 46 Z" fill="#CBD5E1"/>`,
+
+  // ── Overcast ───────────────────────────────────────────────────────────────
+  'overcast': `
+    <path d="M50 44 Q50 32 58 32 Q56 24 49 24 Q47 16 38 18 Q32 10 23 18 Q15 18 15 28 Q15 44 28 44 Z" fill="#94A3B8"/>
+    <path d="M44 52 Q44 42 51 42 Q49 36 43 36 Q41 29 34 31 Q29 25 22 31 Q16 31 16 39 Q16 52 27 52 Z" fill="#CBD5E1"/>`,
+
+  // ── Fog ────────────────────────────────────────────────────────────────────
+  'fog': `
+    <path d="M14 20 Q22 14 32 20 Q42 14 50 20" stroke="#94A3B8" stroke-width="3" stroke-linecap="round" fill="none"/>
+    <path d="M14 32 Q22 26 32 32 Q42 26 50 32" stroke="#94A3B8" stroke-width="3" stroke-linecap="round" fill="none"/>
+    <path d="M14 44 Q22 38 32 44 Q42 38 50 44" stroke="#94A3B8" stroke-width="3" stroke-linecap="round" fill="none"/>
+    <line x1="20" y1="56" x2="44" y2="56" stroke="#CBD5E1" stroke-width="3" stroke-linecap="round"/>`,
+
+  // ── Drizzle ────────────────────────────────────────────────────────────────
+  'drizzle-light': `
+    <path d="M46 36 Q46 24 54 24 Q52 16 45 16 Q43 8 34 10 Q28 4 21 10 Q14 10 14 20 Q14 36 28 36 Z" fill="#CBD5E1"/>
+    <line x1="24" y1="44" x2="22" y2="52" stroke="#60A5FA" stroke-width="2.5" stroke-linecap="round"/>
+    <line x1="34" y1="44" x2="32" y2="52" stroke="#60A5FA" stroke-width="2.5" stroke-linecap="round"/>`,
+
+  'drizzle-moderate': `
+    <path d="M46 36 Q46 24 54 24 Q52 16 45 16 Q43 8 34 10 Q28 4 21 10 Q14 10 14 20 Q14 36 28 36 Z" fill="#94A3B8"/>
+    <line x1="22" y1="43" x2="20" y2="51" stroke="#60A5FA" stroke-width="2.5" stroke-linecap="round"/>
+    <line x1="32" y1="43" x2="30" y2="51" stroke="#60A5FA" stroke-width="2.5" stroke-linecap="round"/>
+    <line x1="42" y1="43" x2="40" y2="51" stroke="#60A5FA" stroke-width="2.5" stroke-linecap="round"/>`,
+
+  'drizzle-heavy': `
+    <path d="M46 36 Q46 24 54 24 Q52 16 45 16 Q43 8 34 10 Q28 4 21 10 Q14 10 14 20 Q14 36 28 36 Z" fill="#64748B"/>
+    <line x1="20" y1="42" x2="18" y2="50" stroke="#60A5FA" stroke-width="2.5" stroke-linecap="round"/>
+    <line x1="29" y1="42" x2="27" y2="50" stroke="#60A5FA" stroke-width="2.5" stroke-linecap="round"/>
+    <line x1="38" y1="42" x2="36" y2="50" stroke="#60A5FA" stroke-width="2.5" stroke-linecap="round"/>
+    <line x1="47" y1="42" x2="45" y2="50" stroke="#60A5FA" stroke-width="2.5" stroke-linecap="round"/>`,
+
+  // ── Rain ───────────────────────────────────────────────────────────────────
+  'rain-light': `
+    <path d="M46 34 Q46 22 54 22 Q52 14 45 14 Q43 6 34 8 Q28 2 21 8 Q14 8 14 18 Q14 34 28 34 Z" fill="#CBD5E1"/>
+    <line x1="24" y1="42" x2="20" y2="54" stroke="#60A5FA" stroke-width="2.5" stroke-linecap="round"/>
+    <line x1="36" y1="42" x2="32" y2="54" stroke="#60A5FA" stroke-width="2.5" stroke-linecap="round"/>`,
+
+  'rain-moderate': `
+    <path d="M46 34 Q46 22 54 22 Q52 14 45 14 Q43 6 34 8 Q28 2 21 8 Q14 8 14 18 Q14 34 28 34 Z" fill="#94A3B8"/>
+    <line x1="22" y1="41" x2="18" y2="53" stroke="#60A5FA" stroke-width="2.5" stroke-linecap="round"/>
+    <line x1="32" y1="41" x2="28" y2="53" stroke="#60A5FA" stroke-width="2.5" stroke-linecap="round"/>
+    <line x1="42" y1="41" x2="38" y2="53" stroke="#60A5FA" stroke-width="2.5" stroke-linecap="round"/>`,
+
+  'rain-heavy': `
+    <path d="M46 34 Q46 22 54 22 Q52 14 45 14 Q43 6 34 8 Q28 2 21 8 Q14 8 14 18 Q14 34 28 34 Z" fill="#64748B"/>
+    <line x1="19" y1="40" x2="15" y2="52" stroke="#3B82F6" stroke-width="3" stroke-linecap="round"/>
+    <line x1="29" y1="40" x2="25" y2="52" stroke="#3B82F6" stroke-width="3" stroke-linecap="round"/>
+    <line x1="39" y1="40" x2="35" y2="52" stroke="#3B82F6" stroke-width="3" stroke-linecap="round"/>
+    <line x1="49" y1="40" x2="45" y2="52" stroke="#3B82F6" stroke-width="3" stroke-linecap="round"/>`,
+
+  // ── Showers (sun + cloud + drops) ─────────────────────────────────────────
+  'showers-light': `
+    <circle cx="20" cy="20" r="9" fill="#FBBF24"/>
+    <g stroke="#FBBF24" stroke-width="2" stroke-linecap="round">
+      <line x1="20" y1="4"  x2="20" y2="8"/>
+      <line x1="4"  y1="20" x2="8"  y2="20"/>
+      <line x1="8"  y1="8"  x2="11" y2="11"/>
+      <line x1="32" y1="8"  x2="29" y2="11"/>
+    </g>
+    <path d="M50 40 Q50 30 57 30 Q55 23 49 23 Q47 17 40 19 Q35 13 28 19 Q22 19 22 27 Q22 40 33 40 Z" fill="#CBD5E1"/>
+    <line x1="30" y1="48" x2="28" y2="56" stroke="#60A5FA" stroke-width="2.5" stroke-linecap="round"/>
+    <line x1="40" y1="48" x2="38" y2="56" stroke="#60A5FA" stroke-width="2.5" stroke-linecap="round"/>`,
+
+  'showers-moderate': `
+    <circle cx="20" cy="20" r="9" fill="#FBBF24"/>
+    <g stroke="#FBBF24" stroke-width="2" stroke-linecap="round">
+      <line x1="20" y1="4"  x2="20" y2="8"/>
+      <line x1="4"  y1="20" x2="8"  y2="20"/>
+      <line x1="8"  y1="8"  x2="11" y2="11"/>
+      <line x1="32" y1="8"  x2="29" y2="11"/>
+    </g>
+    <path d="M50 40 Q50 30 57 30 Q55 23 49 23 Q47 17 40 19 Q35 13 28 19 Q22 19 22 27 Q22 40 33 40 Z" fill="#94A3B8"/>
+    <line x1="28" y1="47" x2="26" y2="55" stroke="#60A5FA" stroke-width="2.5" stroke-linecap="round"/>
+    <line x1="38" y1="47" x2="36" y2="55" stroke="#60A5FA" stroke-width="2.5" stroke-linecap="round"/>
+    <line x1="48" y1="47" x2="46" y2="55" stroke="#60A5FA" stroke-width="2.5" stroke-linecap="round"/>`,
+
+  'showers-heavy': `
+    <circle cx="20" cy="20" r="9" fill="#FBBF24"/>
+    <g stroke="#FBBF24" stroke-width="2" stroke-linecap="round">
+      <line x1="20" y1="4"  x2="20" y2="8"/>
+      <line x1="4"  y1="20" x2="8"  y2="20"/>
+      <line x1="8"  y1="8"  x2="11" y2="11"/>
+      <line x1="32" y1="8"  x2="29" y2="11"/>
+    </g>
+    <path d="M50 40 Q50 30 57 30 Q55 23 49 23 Q47 17 40 19 Q35 13 28 19 Q22 19 22 27 Q22 40 33 40 Z" fill="#64748B"/>
+    <line x1="26" y1="46" x2="24" y2="54" stroke="#3B82F6" stroke-width="3" stroke-linecap="round"/>
+    <line x1="35" y1="46" x2="33" y2="54" stroke="#3B82F6" stroke-width="3" stroke-linecap="round"/>
+    <line x1="44" y1="46" x2="42" y2="54" stroke="#3B82F6" stroke-width="3" stroke-linecap="round"/>`,
+
+  // ── Freezing rain ──────────────────────────────────────────────────────────
+  'freezing-rain': `
+    <path d="M46 34 Q46 22 54 22 Q52 14 45 14 Q43 6 34 8 Q28 2 21 8 Q14 8 14 18 Q14 34 28 34 Z" fill="#94A3B8"/>
+    <line x1="24" y1="42" x2="20" y2="52" stroke="#BAE6FD" stroke-width="2.5" stroke-linecap="round"/>
+    <line x1="34" y1="42" x2="30" y2="52" stroke="#BAE6FD" stroke-width="2.5" stroke-linecap="round"/>
+    <line x1="44" y1="42" x2="40" y2="52" stroke="#BAE6FD" stroke-width="2.5" stroke-linecap="round"/>
+    <circle cx="22" cy="56" r="2.5" fill="#BAE6FD"/>
+    <circle cx="32" cy="56" r="2.5" fill="#BAE6FD"/>
+    <circle cx="42" cy="56" r="2.5" fill="#BAE6FD"/>`,
+
+  // ── Snow ───────────────────────────────────────────────────────────────────
+  'snow-light': `
+    <path d="M46 34 Q46 22 54 22 Q52 14 45 14 Q43 6 34 8 Q28 2 21 8 Q14 8 14 18 Q14 34 28 34 Z" fill="#CBD5E1"/>
+    <g fill="#BAE6FD">
+      <circle cx="24" cy="46" r="3"/>
+      <circle cx="36" cy="50" r="3"/>
+    </g>`,
+
+  'snow-moderate': `
+    <path d="M46 34 Q46 22 54 22 Q52 14 45 14 Q43 6 34 8 Q28 2 21 8 Q14 8 14 18 Q14 34 28 34 Z" fill="#94A3B8"/>
+    <g fill="#BAE6FD">
+      <circle cx="22" cy="44" r="3"/>
+      <circle cx="32" cy="49" r="3"/>
+      <circle cx="42" cy="44" r="3"/>
+      <circle cx="28" cy="56" r="2.5"/>
+      <circle cx="38" cy="56" r="2.5"/>
+    </g>`,
+
+  'snow-heavy': `
+    <path d="M46 34 Q46 22 54 22 Q52 14 45 14 Q43 6 34 8 Q28 2 21 8 Q14 8 14 18 Q14 34 28 34 Z" fill="#64748B"/>
+    <g fill="#BAE6FD">
+      <circle cx="20" cy="43" r="3"/>
+      <circle cx="30" cy="48" r="3"/>
+      <circle cx="40" cy="43" r="3"/>
+      <circle cx="50" cy="48" r="3"/>
+      <circle cx="24" cy="56" r="3"/>
+      <circle cx="36" cy="56" r="3"/>
+      <circle cx="46" cy="56" r="3"/>
+    </g>`,
+
+  // ── Snow showers ───────────────────────────────────────────────────────────
+  'snow-showers-light': `
+    <circle cx="20" cy="20" r="9" fill="#FBBF24"/>
+    <g stroke="#FBBF24" stroke-width="2" stroke-linecap="round">
+      <line x1="20" y1="4"  x2="20" y2="8"/>
+      <line x1="4"  y1="20" x2="8"  y2="20"/>
+      <line x1="8"  y1="8"  x2="11" y2="11"/>
+      <line x1="32" y1="8"  x2="29" y2="11"/>
+    </g>
+    <path d="M50 40 Q50 30 57 30 Q55 23 49 23 Q47 17 40 19 Q35 13 28 19 Q22 19 22 27 Q22 40 33 40 Z" fill="#CBD5E1"/>
+    <g fill="#BAE6FD">
+      <circle cx="30" cy="50" r="3"/>
+      <circle cx="42" cy="50" r="3"/>
+    </g>`,
+
+  'snow-showers-heavy': `
+    <circle cx="20" cy="20" r="9" fill="#FBBF24"/>
+    <g stroke="#FBBF24" stroke-width="2" stroke-linecap="round">
+      <line x1="20" y1="4"  x2="20" y2="8"/>
+      <line x1="4"  y1="20" x2="8"  y2="20"/>
+      <line x1="8"  y1="8"  x2="11" y2="11"/>
+      <line x1="32" y1="8"  x2="29" y2="11"/>
+    </g>
+    <path d="M50 40 Q50 30 57 30 Q55 23 49 23 Q47 17 40 19 Q35 13 28 19 Q22 19 22 27 Q22 40 33 40 Z" fill="#64748B"/>
+    <g fill="#BAE6FD">
+      <circle cx="28" cy="48" r="3"/>
+      <circle cx="38" cy="48" r="3"/>
+      <circle cx="48" cy="48" r="3"/>
+      <circle cx="33" cy="57" r="3"/>
+      <circle cx="43" cy="57" r="3"/>
+    </g>`,
+
+  // ── Thunderstorm ───────────────────────────────────────────────────────────
+  'thunderstorm': `
+    <path d="M46 32 Q46 20 54 20 Q52 12 45 12 Q43 4 34 6 Q28 0 21 6 Q14 6 14 16 Q14 32 28 32 Z" fill="#64748B"/>
+    <polygon points="35,32 28,46 34,46 27,60 42,42 36,42" fill="#FDE68A"/>`,
+
+  'thunderstorm-hail': `
+    <path d="M46 30 Q46 18 54 18 Q52 10 45 10 Q43 2 34 4 Q28 -2 21 4 Q14 4 14 14 Q14 30 28 30 Z" fill="#64748B"/>
+    <polygon points="34,30 27,43 33,43 26,56 41,39 35,39" fill="#FDE68A"/>
+    <g fill="none" stroke="#7DD3FC" stroke-width="1.5">
+      <circle cx="44" cy="50" r="4" fill="#E0F2FE"/>
+      <circle cx="52" cy="56" r="4" fill="#E0F2FE"/>
+    </g>`,
+
+  // ── Unknown / fallback ─────────────────────────────────────────────────────
+  'unknown': `
+    <circle cx="32" cy="32" r="20" stroke="#94A3B8" stroke-width="3" fill="none"/>
+    <text x="32" y="40" text-anchor="middle" font-size="24" fill="#94A3B8">?</text>`,
+}
+
+// ---------------------------------------------------------------------------
+// WMO code → meta mapping
+// ---------------------------------------------------------------------------
 
 const CODE_MAP: Record<number, WeatherCodeMeta> = {
-  0: { description: 'Clear sky', icon: '☀️' },
-  1: { description: 'Mainly clear', icon: '🌤️' },
-  2: { description: 'Partly cloudy', icon: '⛅' },
-  3: { description: 'Overcast', icon: '☁️' },
-  45: { description: 'Fog', icon: '🌫️' },
-  48: { description: 'Icy fog', icon: '🌫️' },
-  51: { description: 'Light drizzle', icon: '🌧️' },
-  53: { description: 'Drizzle', icon: '🌧️' },
-  55: { description: 'Heavy drizzle', icon: '🌧️' },
-  56: { description: 'Light freezing drizzle', icon: '🌧️❄️' },
-  57: { description: 'Heavy freezing drizzle', icon: '🌧️❄️' },
-  61: { description: 'Light rain', icon: '🌧️' },
-  63: { description: 'Rain', icon: '🌧️' },
-  65: { description: 'Heavy rain', icon: '🌧️' },
-  66: { description: 'Light freezing rain', icon: '🌧️❄️' },
-  67: { description: 'Heavy freezing rain', icon: '🌧️❄️' },
-  71: { description: 'Light snow', icon: '🌨️' },
-  73: { description: 'Snow', icon: '🌨️' },
-  75: { description: 'Heavy snow', icon: '🌨️' },
-  77: { description: 'Snow grains', icon: '🌨️' },
-  80: { description: 'Light rain showers', icon: '🌦️' },
-  81: { description: 'Rain showers', icon: '🌦️' },
-  82: { description: 'Violent rain showers', icon: '🌦️' },
-  85: { description: 'Snow showers', icon: '🌨️' },
-  86: { description: 'Heavy snow showers', icon: '🌨️' },
-  95: { description: 'Thunderstorm', icon: '⛈️' },
-  96: { description: 'Thunderstorm with hail', icon: '⛈️' },
-  99: { description: 'Thunderstorm with heavy hail', icon: '⛈️' },
+  0:  { description: 'Clear sky',                   icon: '☀️',     svgKey: 'clear-day' },
+  1:  { description: 'Mainly clear',                icon: '🌤️',    svgKey: 'mostly-clear' },
+  2:  { description: 'Partly cloudy',               icon: '⛅',     svgKey: 'partly-cloudy' },
+  3:  { description: 'Overcast',                    icon: '☁️',     svgKey: 'overcast' },
+  45: { description: 'Fog',                         icon: '🌫️',    svgKey: 'fog' },
+  48: { description: 'Icy fog',                     icon: '🌫️',    svgKey: 'fog' },
+  51: { description: 'Light drizzle',               icon: '🌧️',    svgKey: 'drizzle-light' },
+  53: { description: 'Drizzle',                     icon: '🌧️',    svgKey: 'drizzle-moderate' },
+  55: { description: 'Heavy drizzle',               icon: '🌧️',    svgKey: 'drizzle-heavy' },
+  56: { description: 'Light freezing drizzle',      icon: '🌧️❄️',  svgKey: 'freezing-rain' },
+  57: { description: 'Heavy freezing drizzle',      icon: '🌧️❄️',  svgKey: 'freezing-rain' },
+  61: { description: 'Light rain',                  icon: '🌧️',    svgKey: 'rain-light' },
+  63: { description: 'Rain',                        icon: '🌧️',    svgKey: 'rain-moderate' },
+  65: { description: 'Heavy rain',                  icon: '🌧️',    svgKey: 'rain-heavy' },
+  66: { description: 'Light freezing rain',         icon: '🌧️❄️',  svgKey: 'freezing-rain' },
+  67: { description: 'Heavy freezing rain',         icon: '🌧️❄️',  svgKey: 'freezing-rain' },
+  71: { description: 'Light snow',                  icon: '🌨️',    svgKey: 'snow-light' },
+  73: { description: 'Snow',                        icon: '🌨️',    svgKey: 'snow-moderate' },
+  75: { description: 'Heavy snow',                  icon: '🌨️',    svgKey: 'snow-heavy' },
+  77: { description: 'Snow grains',                 icon: '🌨️',    svgKey: 'snow-light' },
+  80: { description: 'Light rain showers',          icon: '🌦️',    svgKey: 'showers-light' },
+  81: { description: 'Rain showers',                icon: '🌦️',    svgKey: 'showers-moderate' },
+  82: { description: 'Violent rain showers',        icon: '🌦️',    svgKey: 'showers-heavy' },
+  85: { description: 'Snow showers',                icon: '🌨️',    svgKey: 'snow-showers-light' },
+  86: { description: 'Heavy snow showers',          icon: '🌨️',    svgKey: 'snow-showers-heavy' },
+  95: { description: 'Thunderstorm',                icon: '⛈️',    svgKey: 'thunderstorm' },
+  96: { description: 'Thunderstorm with hail',      icon: '⛈️',    svgKey: 'thunderstorm-hail' },
+  99: { description: 'Thunderstorm with heavy hail',icon: '⛈️',    svgKey: 'thunderstorm-hail' },
 }
 
-const FALLBACK: WeatherCodeMeta = { description: 'Unknown', icon: '🌡️' }
+const FALLBACK: WeatherCodeMeta = { description: 'Unknown', icon: '🌡️', svgKey: 'unknown' }
 
 function lookup(code: number): WeatherCodeMeta {
   return CODE_MAP[code] ?? FALLBACK
@@ -49,7 +347,118 @@ export function getWeatherDescription(code: number): string {
   return lookup(code).description
 }
 
+/** @deprecated Prefer getWeatherSvgIcon — emoji output kept for legacy callers */
 export function getWeatherIcon(code: number): string {
+  return lookup(code).icon
+}
+
+// ---------------------------------------------------------------------------
+// Intensity-aware SVG icon resolver
+// ---------------------------------------------------------------------------
+
+/**
+ * Groups of WMO codes that support intensity-differentiated SVG variants.
+ *
+ * Codes not listed here are non-intensity-differentiated (fog, clear, clouds,
+ * thunderstorms, freezing precipitation) — for those the base svgKey is
+ * always returned regardless of the `intensity` argument.
+ */
+type IntensityIconMap = Record<WeatherIntensity, SvgIconKey>
+
+const SVG_INTENSITY_OVERRIDE: Record<number, IntensityIconMap> = {
+  // ── Drizzle (51, 53, 55) ──────────────────────────────────────────────────
+  51: { light: 'drizzle-light',    moderate: 'drizzle-moderate', heavy: 'drizzle-heavy' },
+  53: { light: 'drizzle-light',    moderate: 'drizzle-moderate', heavy: 'drizzle-heavy' },
+  55: { light: 'drizzle-moderate', moderate: 'drizzle-heavy',    heavy: 'drizzle-heavy' },
+
+  // ── Rain (61, 63, 65) ─────────────────────────────────────────────────────
+  61: { light: 'rain-light',    moderate: 'rain-moderate', heavy: 'rain-moderate' },
+  63: { light: 'rain-light',    moderate: 'rain-moderate', heavy: 'rain-heavy' },
+  65: { light: 'rain-moderate', moderate: 'rain-heavy',    heavy: 'rain-heavy' },
+
+  // ── Rain showers (80, 81, 82) ─────────────────────────────────────────────
+  80: { light: 'showers-light',    moderate: 'showers-moderate', heavy: 'showers-moderate' },
+  81: { light: 'showers-light',    moderate: 'showers-moderate', heavy: 'showers-heavy' },
+  82: { light: 'showers-moderate', moderate: 'showers-heavy',    heavy: 'showers-heavy' },
+
+  // ── Snow (71, 73, 75) ─────────────────────────────────────────────────────
+  71: { light: 'snow-light',    moderate: 'snow-moderate', heavy: 'snow-moderate' },
+  73: { light: 'snow-light',    moderate: 'snow-moderate', heavy: 'snow-heavy' },
+  75: { light: 'snow-moderate', moderate: 'snow-heavy',    heavy: 'snow-heavy' },
+
+  // ── Snow showers (85, 86) ─────────────────────────────────────────────────
+  85: { light: 'snow-showers-light', moderate: 'snow-showers-light',  heavy: 'snow-showers-heavy' },
+  86: { light: 'snow-showers-light', moderate: 'snow-showers-heavy',  heavy: 'snow-showers-heavy' },
+}
+
+/**
+ * Return the SVG icon markup (inner `<svg>` content) for `code`, optionally
+ * biased by an intensity hint.
+ *
+ * For codes that support intensity differentiation (rain, drizzle, snow,
+ * showers) the returned SVG may differ from the base icon when `intensity`
+ * is provided. For all other codes (clear, clouds, fog, thunderstorms,
+ * freezing precipitation) the base icon is returned unchanged.
+ *
+ * @param code      WMO weather code
+ * @param intensity Optional severity hint (`'light' | 'moderate' | 'heavy'`).
+ *                  Omit (or pass `undefined`) to use the code's natural icon.
+ */
+export function getWeatherSvgIcon(
+  code: number,
+  intensity?: WeatherIntensity,
+): string {
+  let key: SvgIconKey
+  if (intensity !== undefined) {
+    const override = SVG_INTENSITY_OVERRIDE[code]
+    key = override ? override[intensity] : lookup(code).svgKey
+  } else {
+    key = lookup(code).svgKey
+  }
+  return SVG_ICONS[key]
+}
+
+/**
+ * Intensity-aware emoji resolver — kept for backward compatibility.
+ * Prefer `getWeatherSvgIcon` for visual rendering.
+ *
+ * @deprecated Use getWeatherSvgIcon for SVG rendering.
+ */
+type EmojiIntensityMap = Record<WeatherIntensity, string>
+const INTENSITY_OVERRIDE: Record<number, EmojiIntensityMap> = {
+  // ── Drizzle (51, 53, 55) ──────────────────────────────────────────────────
+  51: { light: '🌦️', moderate: '🌧️', heavy: '🌧️' },
+  53: { light: '🌦️', moderate: '🌧️', heavy: '🌧️' },
+  55: { light: '🌦️', moderate: '🌧️', heavy: '🌧️' },
+
+  // ── Rain (61, 63, 65) ─────────────────────────────────────────────────────
+  61: { light: '🌦️', moderate: '🌧️', heavy: '🌧️' },
+  63: { light: '🌦️', moderate: '🌧️', heavy: '🌧️' },
+  65: { light: '🌦️', moderate: '🌧️', heavy: '⛈️' },
+
+  // ── Rain showers (80, 81, 82) ─────────────────────────────────────────────
+  80: { light: '🌦️', moderate: '🌦️', heavy: '🌧️' },
+  81: { light: '🌦️', moderate: '🌦️', heavy: '🌧️' },
+  82: { light: '🌦️', moderate: '🌧️', heavy: '⛈️' },
+
+  // ── Snow (71, 73, 75) ─────────────────────────────────────────────────────
+  71: { light: '🌨️', moderate: '🌨️', heavy: '❄️' },
+  73: { light: '🌨️', moderate: '🌨️', heavy: '❄️' },
+  75: { light: '🌨️', moderate: '❄️',  heavy: '❄️' },
+
+  // ── Snow showers (85, 86) ─────────────────────────────────────────────────
+  85: { light: '🌨️', moderate: '🌨️', heavy: '❄️' },
+  86: { light: '🌨️', moderate: '❄️',  heavy: '❄️' },
+}
+
+export function getWeatherIconForIntensity(
+  code: number,
+  intensity?: WeatherIntensity,
+): string {
+  if (intensity !== undefined) {
+    const override = INTENSITY_OVERRIDE[code]
+    if (override) return override[intensity]
+  }
   return lookup(code).icon
 }
 

--- a/src/utils/weatherCodes.ts
+++ b/src/utils/weatherCodes.ts
@@ -52,14 +52,19 @@ export type SvgIconKey =
   | 'showers-light'
   | 'showers-moderate'
   | 'showers-heavy'
-  | 'freezing-rain'
+  | 'freezing-drizzle-light'
+  | 'freezing-drizzle-heavy'
+  | 'freezing-rain-light'
+  | 'freezing-rain-heavy'
   | 'snow-light'
   | 'snow-moderate'
   | 'snow-heavy'
   | 'snow-showers-light'
   | 'snow-showers-heavy'
+  | 'fog-icy'
   | 'thunderstorm'
   | 'thunderstorm-hail'
+  | 'thunderstorm-hail-heavy'
   | 'unknown'
 
 // ---------------------------------------------------------------------------
@@ -78,7 +83,7 @@ export type SvgIconKey =
  *   - Lightning:   #FDE68A (amber-200)
  *   - Hail:        #E0F2FE (sky-100) with #7DD3FC border
  *   - Fog lines:   #94A3B8 (slate-400)
- *   - Freeze:      #BAE6FD (sky-200)
+ *   - Freeze:      #BAE6FD (sky-200) lines / #7DD3FC (sky-300) pellet diamonds
  *   - Dark cloud:  #64748B (slate-500) — used for heavy/storm variants
  */
 export const SVG_ICONS: Record<SvgIconKey, string> = {
@@ -134,43 +139,58 @@ export const SVG_ICONS: Record<SvgIconKey, string> = {
     <path d="M14 44 Q22 38 32 44 Q42 38 50 44" stroke="#94A3B8" stroke-width="3" stroke-linecap="round" fill="none"/>
     <line x1="20" y1="56" x2="44" y2="56" stroke="#CBD5E1" stroke-width="3" stroke-linecap="round"/>`,
 
+  // ── Icy fog (WMO 48) ───────────────────────────────────────────────────────
+  // Same three wavy fog lines as 'fog', but ice-crystal diamonds replace the
+  // bottom baseline — shape-first differentiation readable at small sizes.
+  // Diamond points: top, right, bottom, left (cx±4, cy±4 axes).
+  'fog-icy': `
+    <path d="M14 20 Q22 14 32 20 Q42 14 50 20" stroke="#94A3B8" stroke-width="3" stroke-linecap="round" fill="none"/>
+    <path d="M14 32 Q22 26 32 32 Q42 26 50 32" stroke="#94A3B8" stroke-width="3" stroke-linecap="round" fill="none"/>
+    <path d="M14 44 Q22 38 32 44 Q42 38 50 44" stroke="#94A3B8" stroke-width="3" stroke-linecap="round" fill="none"/>
+    <polygon points="22,52 26,56 22,60 18,56" fill="#BAE6FD" stroke="#7DD3FC" stroke-width="1"/>
+    <polygon points="32,52 36,56 32,60 28,56" fill="#BAE6FD" stroke="#7DD3FC" stroke-width="1"/>
+    <polygon points="42,52 46,56 42,60 38,56" fill="#BAE6FD" stroke="#7DD3FC" stroke-width="1"/>`,
+
   // ── Drizzle ────────────────────────────────────────────────────────────────
+  // Short, fine marks (length ≈5, stroke-width 1.5) — clearly lighter than rain
   'drizzle-light': `
     <path d="M46 36 Q46 24 54 24 Q52 16 45 16 Q43 8 34 10 Q28 4 21 10 Q14 10 14 20 Q14 36 28 36 Z" fill="#CBD5E1"/>
-    <line x1="24" y1="44" x2="22" y2="52" stroke="#60A5FA" stroke-width="2.5" stroke-linecap="round"/>
-    <line x1="34" y1="44" x2="32" y2="52" stroke="#60A5FA" stroke-width="2.5" stroke-linecap="round"/>`,
+    <line x1="24" y1="44" x2="23" y2="49" stroke="#60A5FA" stroke-width="1.5" stroke-linecap="round"/>
+    <line x1="34" y1="44" x2="33" y2="49" stroke="#60A5FA" stroke-width="1.5" stroke-linecap="round"/>`,
 
   'drizzle-moderate': `
     <path d="M46 36 Q46 24 54 24 Q52 16 45 16 Q43 8 34 10 Q28 4 21 10 Q14 10 14 20 Q14 36 28 36 Z" fill="#94A3B8"/>
-    <line x1="22" y1="43" x2="20" y2="51" stroke="#60A5FA" stroke-width="2.5" stroke-linecap="round"/>
-    <line x1="32" y1="43" x2="30" y2="51" stroke="#60A5FA" stroke-width="2.5" stroke-linecap="round"/>
-    <line x1="42" y1="43" x2="40" y2="51" stroke="#60A5FA" stroke-width="2.5" stroke-linecap="round"/>`,
+    <line x1="22" y1="43" x2="21" y2="48" stroke="#60A5FA" stroke-width="1.5" stroke-linecap="round"/>
+    <line x1="32" y1="43" x2="31" y2="48" stroke="#60A5FA" stroke-width="1.5" stroke-linecap="round"/>
+    <line x1="42" y1="43" x2="41" y2="48" stroke="#60A5FA" stroke-width="1.5" stroke-linecap="round"/>`,
 
   'drizzle-heavy': `
     <path d="M46 36 Q46 24 54 24 Q52 16 45 16 Q43 8 34 10 Q28 4 21 10 Q14 10 14 20 Q14 36 28 36 Z" fill="#64748B"/>
-    <line x1="20" y1="42" x2="18" y2="50" stroke="#60A5FA" stroke-width="2.5" stroke-linecap="round"/>
-    <line x1="29" y1="42" x2="27" y2="50" stroke="#60A5FA" stroke-width="2.5" stroke-linecap="round"/>
-    <line x1="38" y1="42" x2="36" y2="50" stroke="#60A5FA" stroke-width="2.5" stroke-linecap="round"/>
-    <line x1="47" y1="42" x2="45" y2="50" stroke="#60A5FA" stroke-width="2.5" stroke-linecap="round"/>`,
+    <line x1="20" y1="42" x2="19" y2="47" stroke="#60A5FA" stroke-width="1.5" stroke-linecap="round"/>
+    <line x1="29" y1="42" x2="28" y2="47" stroke="#60A5FA" stroke-width="1.5" stroke-linecap="round"/>
+    <line x1="38" y1="42" x2="37" y2="47" stroke="#60A5FA" stroke-width="1.5" stroke-linecap="round"/>
+    <line x1="47" y1="42" x2="46" y2="47" stroke="#60A5FA" stroke-width="1.5" stroke-linecap="round"/>`,
 
   // ── Rain ───────────────────────────────────────────────────────────────────
+  // Medium streaks (length ≈10, stroke-width 2.5) — clearly heavier than drizzle
   'rain-light': `
     <path d="M46 34 Q46 22 54 22 Q52 14 45 14 Q43 6 34 8 Q28 2 21 8 Q14 8 14 18 Q14 34 28 34 Z" fill="#CBD5E1"/>
-    <line x1="24" y1="42" x2="20" y2="54" stroke="#60A5FA" stroke-width="2.5" stroke-linecap="round"/>
-    <line x1="36" y1="42" x2="32" y2="54" stroke="#60A5FA" stroke-width="2.5" stroke-linecap="round"/>`,
+    <line x1="24" y1="42" x2="21" y2="52" stroke="#60A5FA" stroke-width="2.5" stroke-linecap="round"/>
+    <line x1="36" y1="42" x2="33" y2="52" stroke="#60A5FA" stroke-width="2.5" stroke-linecap="round"/>`,
 
   'rain-moderate': `
     <path d="M46 34 Q46 22 54 22 Q52 14 45 14 Q43 6 34 8 Q28 2 21 8 Q14 8 14 18 Q14 34 28 34 Z" fill="#94A3B8"/>
-    <line x1="22" y1="41" x2="18" y2="53" stroke="#60A5FA" stroke-width="2.5" stroke-linecap="round"/>
-    <line x1="32" y1="41" x2="28" y2="53" stroke="#60A5FA" stroke-width="2.5" stroke-linecap="round"/>
-    <line x1="42" y1="41" x2="38" y2="53" stroke="#60A5FA" stroke-width="2.5" stroke-linecap="round"/>`,
+    <line x1="22" y1="41" x2="19" y2="51" stroke="#60A5FA" stroke-width="2.5" stroke-linecap="round"/>
+    <line x1="32" y1="41" x2="29" y2="51" stroke="#60A5FA" stroke-width="2.5" stroke-linecap="round"/>
+    <line x1="42" y1="41" x2="39" y2="51" stroke="#60A5FA" stroke-width="2.5" stroke-linecap="round"/>`,
 
+  // Long, bold streaks (length ≈15, stroke-width 3) — unmistakably heavy
   'rain-heavy': `
     <path d="M46 34 Q46 22 54 22 Q52 14 45 14 Q43 6 34 8 Q28 2 21 8 Q14 8 14 18 Q14 34 28 34 Z" fill="#64748B"/>
-    <line x1="19" y1="40" x2="15" y2="52" stroke="#3B82F6" stroke-width="3" stroke-linecap="round"/>
-    <line x1="29" y1="40" x2="25" y2="52" stroke="#3B82F6" stroke-width="3" stroke-linecap="round"/>
-    <line x1="39" y1="40" x2="35" y2="52" stroke="#3B82F6" stroke-width="3" stroke-linecap="round"/>
-    <line x1="49" y1="40" x2="45" y2="52" stroke="#3B82F6" stroke-width="3" stroke-linecap="round"/>`,
+    <line x1="19" y1="40" x2="14" y2="55" stroke="#3B82F6" stroke-width="3" stroke-linecap="round"/>
+    <line x1="29" y1="40" x2="24" y2="55" stroke="#3B82F6" stroke-width="3" stroke-linecap="round"/>
+    <line x1="39" y1="40" x2="34" y2="55" stroke="#3B82F6" stroke-width="3" stroke-linecap="round"/>
+    <line x1="49" y1="40" x2="44" y2="55" stroke="#3B82F6" stroke-width="3" stroke-linecap="round"/>`,
 
   // ── Showers (sun + cloud + drops) ─────────────────────────────────────────
   'showers-light': `
@@ -207,19 +227,59 @@ export const SVG_ICONS: Record<SvgIconKey, string> = {
       <line x1="32" y1="8"  x2="29" y2="11"/>
     </g>
     <path d="M50 40 Q50 30 57 30 Q55 23 49 23 Q47 17 40 19 Q35 13 28 19 Q22 19 22 27 Q22 40 33 40 Z" fill="#64748B"/>
-    <line x1="26" y1="46" x2="24" y2="54" stroke="#3B82F6" stroke-width="3" stroke-linecap="round"/>
-    <line x1="35" y1="46" x2="33" y2="54" stroke="#3B82F6" stroke-width="3" stroke-linecap="round"/>
-    <line x1="44" y1="46" x2="42" y2="54" stroke="#3B82F6" stroke-width="3" stroke-linecap="round"/>`,
+    <line x1="24" y1="46" x2="22" y2="54" stroke="#3B82F6" stroke-width="3" stroke-linecap="round"/>
+    <line x1="32" y1="46" x2="30" y2="54" stroke="#3B82F6" stroke-width="3" stroke-linecap="round"/>
+    <line x1="40" y1="46" x2="38" y2="54" stroke="#3B82F6" stroke-width="3" stroke-linecap="round"/>
+    <line x1="48" y1="46" x2="46" y2="54" stroke="#3B82F6" stroke-width="3" stroke-linecap="round"/>`,
 
-  // ── Freezing rain ──────────────────────────────────────────────────────────
-  'freezing-rain': `
-    <path d="M46 34 Q46 22 54 22 Q52 14 45 14 Q43 6 34 8 Q28 2 21 8 Q14 8 14 18 Q14 34 28 34 Z" fill="#94A3B8"/>
-    <line x1="24" y1="42" x2="20" y2="52" stroke="#BAE6FD" stroke-width="2.5" stroke-linecap="round"/>
-    <line x1="34" y1="42" x2="30" y2="52" stroke="#BAE6FD" stroke-width="2.5" stroke-linecap="round"/>
-    <line x1="44" y1="42" x2="40" y2="52" stroke="#BAE6FD" stroke-width="2.5" stroke-linecap="round"/>
-    <circle cx="22" cy="56" r="2.5" fill="#BAE6FD"/>
-    <circle cx="32" cy="56" r="2.5" fill="#BAE6FD"/>
-    <circle cx="42" cy="56" r="2.5" fill="#BAE6FD"/>`,
+  // ── Freezing drizzle (WMO 56 = light, 57 = heavy) ────────────────────────
+  // Short, fine strokes in ice-blue (#BAE6FD, length ≈5, stroke-width 1.5)
+  // mirror the drizzle stroke language; terminal frozen circles mark the freeze
+  // modifier. Uses the drizzle cloud path to reinforce the fine-precipitation
+  // read, while the ice-blue palette distinguishes it from normal drizzle.
+  // Light = 2 strokes+circles, heavy = 4 strokes+circles.
+  'freezing-drizzle-light': `
+    <path d="M46 36 Q46 24 54 24 Q52 16 45 16 Q43 8 34 10 Q28 4 21 10 Q14 10 14 20 Q14 36 28 36 Z" fill="#CBD5E1"/>
+    <line x1="24" y1="44" x2="23" y2="49" stroke="#BAE6FD" stroke-width="1.5" stroke-linecap="round"/>
+    <line x1="34" y1="44" x2="33" y2="49" stroke="#BAE6FD" stroke-width="1.5" stroke-linecap="round"/>
+    <circle cx="25" cy="53" r="2" fill="#BAE6FD"/>
+    <circle cx="35" cy="53" r="2" fill="#BAE6FD"/>`,
+
+  'freezing-drizzle-heavy': `
+    <path d="M46 36 Q46 24 54 24 Q52 16 45 16 Q43 8 34 10 Q28 4 21 10 Q14 10 14 20 Q14 36 28 36 Z" fill="#64748B"/>
+    <line x1="18" y1="42" x2="17" y2="47" stroke="#BAE6FD" stroke-width="1.5" stroke-linecap="round"/>
+    <line x1="27" y1="42" x2="26" y2="47" stroke="#BAE6FD" stroke-width="1.5" stroke-linecap="round"/>
+    <line x1="36" y1="42" x2="35" y2="47" stroke="#BAE6FD" stroke-width="1.5" stroke-linecap="round"/>
+    <line x1="45" y1="42" x2="44" y2="47" stroke="#BAE6FD" stroke-width="1.5" stroke-linecap="round"/>
+    <circle cx="19" cy="51" r="2" fill="#BAE6FD"/>
+    <circle cx="28" cy="51" r="2" fill="#BAE6FD"/>
+    <circle cx="37" cy="51" r="2" fill="#BAE6FD"/>
+    <circle cx="46" cy="51" r="2" fill="#BAE6FD"/>`,
+
+  // ── Freezing rain (WMO 66 = light, 67 = heavy) ───────────────────────────
+  // Longer rain-style streaks in ice-blue (#BAE6FD, length ≈10, stroke-width 2.5)
+  // mirror the rain stroke language; small filled circles at streak-ends signal
+  // the frozen state. Ice-blue palette (vs. blue-400 for normal rain) marks the
+  // freeze modifier. Distinct from snow (soft circles, no streaks) and normal
+  // rain (blue-400 diagonal streaks, no terminal circles).
+  // Light = 2 strokes+circles, heavy = 4 strokes+circles.
+  'freezing-rain-light': `
+    <path d="M46 34 Q46 22 54 22 Q52 14 45 14 Q43 6 34 8 Q28 2 21 8 Q14 8 14 18 Q14 34 28 34 Z" fill="#CBD5E1"/>
+    <line x1="26" y1="42" x2="22" y2="52" stroke="#BAE6FD" stroke-width="2.5" stroke-linecap="round"/>
+    <line x1="40" y1="42" x2="36" y2="52" stroke="#BAE6FD" stroke-width="2.5" stroke-linecap="round"/>
+    <circle cx="24" cy="56" r="2.5" fill="#BAE6FD"/>
+    <circle cx="38" cy="56" r="2.5" fill="#BAE6FD"/>`,
+
+  'freezing-rain-heavy': `
+    <path d="M46 34 Q46 22 54 22 Q52 14 45 14 Q43 6 34 8 Q28 2 21 8 Q14 8 14 18 Q14 34 28 34 Z" fill="#64748B"/>
+    <line x1="19" y1="40" x2="15" y2="50" stroke="#BAE6FD" stroke-width="2.5" stroke-linecap="round"/>
+    <line x1="29" y1="40" x2="25" y2="50" stroke="#BAE6FD" stroke-width="2.5" stroke-linecap="round"/>
+    <line x1="39" y1="40" x2="35" y2="50" stroke="#BAE6FD" stroke-width="2.5" stroke-linecap="round"/>
+    <line x1="49" y1="40" x2="45" y2="50" stroke="#BAE6FD" stroke-width="2.5" stroke-linecap="round"/>
+    <circle cx="17" cy="54" r="2.5" fill="#BAE6FD"/>
+    <circle cx="27" cy="54" r="2.5" fill="#BAE6FD"/>
+    <circle cx="37" cy="54" r="2.5" fill="#BAE6FD"/>
+    <circle cx="47" cy="54" r="2.5" fill="#BAE6FD"/>`,
 
   // ── Snow ───────────────────────────────────────────────────────────────────
   'snow-light': `
@@ -296,6 +356,22 @@ export const SVG_ICONS: Record<SvgIconKey, string> = {
       <circle cx="52" cy="56" r="4" fill="#E0F2FE"/>
     </g>`,
 
+  // ── Thunderstorm with heavy hail (WMO 99) ─────────────────────────────────
+  // Shape-first differentiation from normal hail (WMO 96):
+  //   • Cloud spans the full width (left edge at x=10 vs x=14) for a bigger,
+  //     more threatening profile.
+  //   • Four hail pellets (vs two) in a 2×2 grid, with larger radii (r=5 vs r=4),
+  //     so the denser pellet field is unmistakable even at small render sizes.
+  'thunderstorm-hail-heavy': `
+    <path d="M48 30 Q48 18 56 18 Q54 10 47 10 Q45 2 36 4 Q30 -2 22 4 Q14 4 14 14 Q14 30 28 30 Z" fill="#475569"/>
+    <polygon points="34,30 27,43 33,43 26,56 41,39 35,39" fill="#FDE68A"/>
+    <g fill="#E0F2FE" stroke="#7DD3FC" stroke-width="1.5">
+      <circle cx="40" cy="46" r="5"/>
+      <circle cx="52" cy="46" r="5"/>
+      <circle cx="40" cy="58" r="5"/>
+      <circle cx="52" cy="58" r="5"/>
+    </g>`,
+
   // ── Unknown / fallback ─────────────────────────────────────────────────────
   'unknown': `
     <circle cx="32" cy="32" r="20" stroke="#94A3B8" stroke-width="3" fill="none"/>
@@ -312,17 +388,17 @@ const CODE_MAP: Record<number, WeatherCodeMeta> = {
   2:  { description: 'Partly cloudy',               icon: '⛅',     svgKey: 'partly-cloudy' },
   3:  { description: 'Overcast',                    icon: '☁️',     svgKey: 'overcast' },
   45: { description: 'Fog',                         icon: '🌫️',    svgKey: 'fog' },
-  48: { description: 'Icy fog',                     icon: '🌫️',    svgKey: 'fog' },
+  48: { description: 'Icy fog',                     icon: '🌫️',    svgKey: 'fog-icy' },
   51: { description: 'Light drizzle',               icon: '🌧️',    svgKey: 'drizzle-light' },
   53: { description: 'Drizzle',                     icon: '🌧️',    svgKey: 'drizzle-moderate' },
   55: { description: 'Heavy drizzle',               icon: '🌧️',    svgKey: 'drizzle-heavy' },
-  56: { description: 'Light freezing drizzle',      icon: '🌧️❄️',  svgKey: 'freezing-rain' },
-  57: { description: 'Heavy freezing drizzle',      icon: '🌧️❄️',  svgKey: 'freezing-rain' },
+  56: { description: 'Light freezing drizzle',      icon: '🌧️❄️',  svgKey: 'freezing-drizzle-light' },
+  57: { description: 'Heavy freezing drizzle',      icon: '🌧️❄️',  svgKey: 'freezing-drizzle-heavy' },
   61: { description: 'Light rain',                  icon: '🌧️',    svgKey: 'rain-light' },
   63: { description: 'Rain',                        icon: '🌧️',    svgKey: 'rain-moderate' },
   65: { description: 'Heavy rain',                  icon: '🌧️',    svgKey: 'rain-heavy' },
-  66: { description: 'Light freezing rain',         icon: '🌧️❄️',  svgKey: 'freezing-rain' },
-  67: { description: 'Heavy freezing rain',         icon: '🌧️❄️',  svgKey: 'freezing-rain' },
+  66: { description: 'Light freezing rain',         icon: '🌧️❄️',  svgKey: 'freezing-rain-light' },
+  67: { description: 'Heavy freezing rain',         icon: '🌧️❄️',  svgKey: 'freezing-rain-heavy' },
   71: { description: 'Light snow',                  icon: '🌨️',    svgKey: 'snow-light' },
   73: { description: 'Snow',                        icon: '🌨️',    svgKey: 'snow-moderate' },
   75: { description: 'Heavy snow',                  icon: '🌨️',    svgKey: 'snow-heavy' },
@@ -334,7 +410,7 @@ const CODE_MAP: Record<number, WeatherCodeMeta> = {
   86: { description: 'Heavy snow showers',          icon: '🌨️',    svgKey: 'snow-showers-heavy' },
   95: { description: 'Thunderstorm',                icon: '⛈️',    svgKey: 'thunderstorm' },
   96: { description: 'Thunderstorm with hail',      icon: '⛈️',    svgKey: 'thunderstorm-hail' },
-  99: { description: 'Thunderstorm with heavy hail',icon: '⛈️',    svgKey: 'thunderstorm-hail' },
+  99: { description: 'Thunderstorm with heavy hail',icon: '⛈️',    svgKey: 'thunderstorm-hail-heavy' },
 }
 
 const FALLBACK: WeatherCodeMeta = { description: 'Unknown', icon: '🌡️', svgKey: 'unknown' }
@@ -359,8 +435,8 @@ export function getWeatherIcon(code: number): string {
 /**
  * Groups of WMO codes that support intensity-differentiated SVG variants.
  *
- * Codes not listed here are non-intensity-differentiated (fog, clear, clouds,
- * thunderstorms, freezing precipitation) — for those the base svgKey is
+ * Codes not listed here are non-intensity-differentiated (fog, icy fog, clear,
+ * clouds, thunderstorms, freezing precipitation) — for those the base svgKey is
  * always returned regardless of the `intensity` argument.
  */
 type IntensityIconMap = Record<WeatherIntensity, SvgIconKey>


### PR DESCRIPTION
## Summary
- replace emoji-based weather rendering with shared SVG icons across the current, hourly, and daily forecasts
- add precipitation-aware intensity handling, richer weather inputs, and clearer icon distinctions for drizzle, rain, showers, freezing precipitation, fog, and hail variants
- add a dev-only in-app weather icon showcase at the bottom of the app for reviewing all icon states during development

## Verification
- bun run type-check
- bun run build