### PR TITLE
feat: night improvements (issue #5) + sunrise/sunset tile

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, onMounted, ref, watch } from 'vue'
+import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
 import { useGeolocation } from '@/composables/useGeolocation'
 import { useOnlineStatus } from '@/composables/useOnlineStatus'
 import { usePullToRefresh } from '@/composables/usePullToRefresh'
@@ -47,6 +47,27 @@ const themeIcon = computed(() => {
   return '⚙️'
 })
 
+// ── Stale data auto-refresh ──────────────────────────────────────────────────
+const STALE_THRESHOLD_MS = 30 * 60 * 1000 // 30 minutes
+
+function isDataStale(): boolean {
+  const last = weatherStore.lastUpdated
+  if (!last) return true
+  return Date.now() - last.getTime() > STALE_THRESHOLD_MS
+}
+
+function refreshIfStale(): void {
+  if (isDataStale()) {
+    void refreshAll()
+  }
+}
+
+function onVisibilityChange(): void {
+  if (document.visibilityState === 'visible') {
+    refreshIfStale()
+  }
+}
+
 // ── Refresh all data for the current location ───────────────────────────────
 async function refreshAll(): Promise<void> {
   const lat = locationStore.latitude
@@ -72,6 +93,10 @@ const isLoading = computed(() => weatherStore.loading || precipitationStore.load
 const isEditingLocation = ref(false)
 
 onMounted(async () => {
+  // Register visibility-change handler to auto-refresh stale data when the
+  // user returns to the tab after 30+ minutes away.
+  document.addEventListener('visibilitychange', onVisibilityChange)
+
   // Fetch weather + precipitation for the initial/persisted location immediately
   void weatherStore.fetchWeather(locationStore.latitude, locationStore.longitude)
   void precipitationStore.fetchPrecipitation(locationStore.latitude, locationStore.longitude)
@@ -91,6 +116,10 @@ onMounted(async () => {
     }
   }
   // On failure the store already holds Amsterdam (or last persisted location)
+})
+
+onUnmounted(() => {
+  document.removeEventListener('visibilitychange', onVisibilityChange)
 })
 
 // Re-fetch weather + precipitation whenever the location changes (e.g. user picks a city)

--- a/src/components/CurrentWeather.vue
+++ b/src/components/CurrentWeather.vue
@@ -4,12 +4,14 @@ import { useWeatherStore } from '@/stores/weather'
 import { usePrecipitationStore } from '@/stores/precipitation'
 import { getWeatherDescription, degreesToCompass } from '@/utils/weatherCodes'
 import type { WeatherIntensity } from '@/utils/weatherCodes'
+import { useMoonPhase } from '@/composables/useMoonPhase'
 import WeatherIcon from '@/components/WeatherIcon.vue'
 
 defineEmits<{ (e: 'open-radar'): void }>()
 
 const weatherStore = useWeatherStore()
 const precipStore = usePrecipitationStore()
+const moonPhase = useMoonPhase()
 
 const weather = computed(() => weatherStore.currentWeather)
 const loading = computed(() => weatherStore.loading)
@@ -160,8 +162,8 @@ const gridLines = computed(() => {
       <!-- Description skeleton -->
       <div class="mb-6 h-5 w-40 animate-pulse rounded-lg bg-slate-200 dark:bg-white/20" />
       <!-- Stats row skeleton -->
-      <div class="grid grid-cols-3 gap-3">
-        <div v-for="i in 3" :key="i" class="h-16 animate-pulse rounded-xl bg-slate-200 dark:bg-white/20" />
+      <div class="grid grid-cols-2 gap-3">
+        <div v-for="i in 4" :key="i" class="h-16 animate-pulse rounded-xl bg-slate-200 dark:bg-white/20" />
       </div>
 
       <!-- Divider skeleton -->
@@ -227,6 +229,7 @@ const gridLines = computed(() => {
         <WeatherIcon
           :code="weather.weatherCode"
           :intensity="currentWeatherIntensity"
+          :is-day="weather.isDay"
           :size="64"
           class="drop-shadow-md transition-all duration-300"
         />
@@ -238,12 +241,14 @@ const gridLines = computed(() => {
       </p>
 
       <!-- Stats grid -->
-      <div class="grid grid-cols-3 gap-3">
+      <div class="grid grid-cols-2 gap-3">
         <!-- Feels like -->
         <div
           class="flex flex-col items-center gap-1 rounded-2xl border border-slate-200 dark:border-white/10 bg-white/50 dark:bg-white/10 px-2 py-3 text-center"
         >
-          <span class="text-xl" aria-hidden="true">🌡️</span>
+          <svg class="size-5 text-slate-500 dark:text-white/60" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <path d="M14 14.76V3.5a2.5 2.5 0 0 0-5 0v11.26a4.5 4.5 0 1 0 5 0Z"/>
+          </svg>
           <span class="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-white/60">Feels like</span>
           <span class="text-base font-semibold">{{ feelsLike }}°C</span>
         </div>
@@ -252,7 +257,9 @@ const gridLines = computed(() => {
         <div
           class="flex flex-col items-center gap-1 rounded-2xl border border-slate-200 dark:border-white/10 bg-white/50 dark:bg-white/10 px-2 py-3 text-center"
         >
-          <span class="text-xl" aria-hidden="true">💧</span>
+          <svg class="size-5 text-slate-500 dark:text-white/60" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <path d="M12 2.69l5.66 5.66a8 8 0 1 1-11.31 0Z"/>
+          </svg>
           <span class="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-white/60">Humidity</span>
           <span class="text-base font-semibold">{{ weather.humidity }}%</span>
         </div>
@@ -261,13 +268,24 @@ const gridLines = computed(() => {
         <div
           class="flex flex-col items-center gap-1 rounded-2xl border border-slate-200 dark:border-white/10 bg-white/50 dark:bg-white/10 px-2 py-3 text-center"
         >
-          <span class="text-xl" aria-hidden="true">💨</span>
+          <svg class="size-5 text-slate-500 dark:text-white/60" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <path d="M9.59 4.59A2 2 0 1 1 11 8H2m10.59 11.41A2 2 0 1 0 14 16H2m15.73-8.27A2.5 2.5 0 1 1 19.5 12H2"/>
+          </svg>
           <span class="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-white/60">Wind</span>
           <span class="text-base font-semibold">
             {{ Math.round(weather.windSpeed) }}
             <span class="text-xs font-normal text-slate-500 dark:text-white/70">km/h</span>
           </span>
           <span class="text-xs text-slate-500 dark:text-white/60">{{ windCompass }}</span>
+        </div>
+
+        <!-- Moon phase -->
+        <div
+          class="flex flex-col items-center gap-1 rounded-2xl border border-slate-200 dark:border-white/10 bg-white/50 dark:bg-white/10 px-2 py-3 text-center"
+        >
+          <svg class="size-5 shrink-0" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" v-html="moonPhase.phaseIcon" />
+          <span class="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-white/60">Moon</span>
+          <span class="text-base font-semibold leading-tight">{{ moonPhase.phaseName }}</span>
         </div>
       </div>
 

--- a/src/components/CurrentWeather.vue
+++ b/src/components/CurrentWeather.vue
@@ -14,8 +14,22 @@ const precipStore = usePrecipitationStore()
 const moonPhase = useMoonPhase()
 
 const weather = computed(() => weatherStore.currentWeather)
+const daily = computed(() => weatherStore.dailyForecast)
 const loading = computed(() => weatherStore.loading)
 const error = computed(() => weatherStore.error)
+
+/** Format an ISO datetime string (e.g. "2026-04-02T06:14") to "HH:MM" */
+function formatTime(iso: string): string {
+  const d = new Date(iso)
+  return d.toLocaleTimeString('nl-NL', { hour: '2-digit', minute: '2-digit', hour12: false })
+}
+
+const todaySunrise = computed<string | null>(() =>
+  daily.value?.sunrise?.[0] ? formatTime(daily.value.sunrise[0]) : null,
+)
+const todaySunset = computed<string | null>(() =>
+  daily.value?.sunset?.[0] ? formatTime(daily.value.sunset[0]) : null,
+)
 
 const temperature = computed(() =>
   weather.value !== null ? Math.round(weather.value.temperature) : null,
@@ -286,6 +300,44 @@ const gridLines = computed(() => {
           <svg class="size-5 shrink-0" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" v-html="moonPhase.phaseIcon" />
           <span class="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-white/60">Moon</span>
           <span class="text-base font-semibold leading-tight">{{ moonPhase.phaseName }}</span>
+        </div>
+      </div>
+
+      <!-- Sunrise / Sunset tile -->
+      <div
+        v-if="todaySunrise || todaySunset"
+        class="mt-3 flex items-center justify-around rounded-2xl border border-slate-200 dark:border-white/10 bg-white/50 dark:bg-white/10 px-4 py-3"
+      >
+        <!-- Sunrise -->
+        <div class="flex items-center gap-2">
+          <!-- Sunrise icon: sun rising above horizon line -->
+          <svg class="size-5 shrink-0 text-amber-500 dark:text-amber-400" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <path d="M12 2v2M4.93 4.93l1.41 1.41M2 12h2M20 12h2M18.66 4.93l-1.41 1.41"/>
+            <path d="M5 17a7 7 0 0 1 14 0"/>
+            <line x1="2" y1="20" x2="22" y2="20"/>
+          </svg>
+          <div class="text-center">
+            <p class="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-white/60">Sunrise</p>
+            <p class="text-base font-semibold">{{ todaySunrise }}</p>
+          </div>
+        </div>
+
+        <!-- Divider -->
+        <div class="h-8 w-px bg-slate-200 dark:bg-white/10" aria-hidden="true" />
+
+        <!-- Sunset -->
+        <div class="flex items-center gap-2">
+          <!-- Sunset icon: sun setting below horizon line -->
+          <svg class="size-5 shrink-0 text-orange-500 dark:text-orange-400" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <path d="M12 10v2M4.93 4.93l1.41 1.41M2 12h2M20 12h2M18.66 4.93l-1.41 1.41"/>
+            <path d="M5 17a7 7 0 0 1 14 0"/>
+            <line x1="2" y1="20" x2="22" y2="20"/>
+            <path d="M12 6l-1.5 2h3L12 6z" fill="currentColor" stroke="none"/>
+          </svg>
+          <div class="text-center">
+            <p class="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-white/60">Sunset</p>
+            <p class="text-base font-semibold">{{ todaySunset }}</p>
+          </div>
         </div>
       </div>
 

--- a/src/components/HourlyForecast.vue
+++ b/src/components/HourlyForecast.vue
@@ -21,6 +21,7 @@ interface HourlyCard {
   temp: number
   precip: number
   precipProb: number
+  isDay: boolean | null
 }
 
 const hourlyCards = computed<HourlyCard[]>(() => {
@@ -31,6 +32,7 @@ const hourlyCards = computed<HourlyCard[]>(() => {
     temp: Math.round(forecast.value!.temperature[i] ?? 0),
     precip: forecast.value!.precipitation[i] ?? 0,
     precipProb: forecast.value!.precipitationProbability[i] ?? 0,
+    isDay: forecast.value!.isDay !== null ? (forecast.value!.isDay[i] === 1) : null,
   }))
 })
 </script>
@@ -108,6 +110,7 @@ const hourlyCards = computed<HourlyCard[]>(() => {
           <WeatherIcon
             :code="card.code"
             :intensity="card.precip > 7.6 ? 'heavy' : card.precip >= 0.5 ? 'moderate' : card.precip > 0 ? 'light' : undefined"
+            :is-day="card.isDay"
             :size="28"
           />
           <!-- Temperature -->

--- a/src/components/WeatherIcon.vue
+++ b/src/components/WeatherIcon.vue
@@ -13,6 +13,8 @@
  *             When provided, codes that support intensity differentiation
  *             (rain, drizzle, snow, showers) may return a distinct SVG variant.
  *             Omit to use the code's natural icon.
+ * isDay       (optional) — pass `false` to use night icon variants (moon
+ *             instead of sun for clear/partly-cloudy/shower codes).
  * size        (optional) — pixel size for the SVG (width & height). Defaults to 32.
  * label       (optional) — Accessible label string. When omitted the element
  *             is marked aria-hidden="true" (decorative).
@@ -24,6 +26,9 @@
  *
  * <!-- With intensity hint -->
  * <WeatherIcon :code="63" intensity="heavy" />
+ *
+ * <!-- Night mode -->
+ * <WeatherIcon :code="0" :is-day="false" />
  *
  * <!-- Custom size + accessible label -->
  * <WeatherIcon :code="0" :size="64" label="Clear sky" />
@@ -38,6 +43,8 @@ const props = withDefaults(
     code: number
     /** Optional precipitation / severity intensity hint */
     intensity?: WeatherIntensity
+    /** Whether it is daytime. Pass false to use night icon variants. */
+    isDay?: boolean | null
     /** SVG size in pixels (width & height, default: 32) */
     size?: number
     /** Accessible label — omit for decorative icons */
@@ -45,12 +52,13 @@ const props = withDefaults(
   }>(),
   {
     intensity: undefined,
+    isDay: undefined,
     size: 32,
     label: undefined,
   },
 )
 
-const svgPath = computed(() => getWeatherSvgIcon(props.code, props.intensity))
+const svgPath = computed(() => getWeatherSvgIcon(props.code, props.intensity, props.isDay))
 const ariaLabel = computed(() => props.label ?? getWeatherDescription(props.code))
 const isDecorative = computed(() => props.label === undefined)
 </script>

--- a/src/components/WeatherIconDemo.vue
+++ b/src/components/WeatherIconDemo.vue
@@ -8,6 +8,7 @@
  */
 import WeatherIcon from '@/components/WeatherIcon.vue'
 import type { WeatherIntensity } from '@/utils/weatherCodes'
+import { getMoonPhaseName, getMoonPhaseIcon } from '@/composables/useMoonPhase'
 
 interface IconEntry {
   /** WMO code to pass to WeatherIcon */
@@ -16,6 +17,8 @@ interface IconEntry {
   label: string
   /** Optional intensity override */
   intensity?: WeatherIntensity
+  /** Pass false to show night variant */
+  isDay?: boolean
 }
 
 interface IconGroup {
@@ -33,6 +36,15 @@ const groups: IconGroup[] = [
       { code: 3,  label: 'Overcast' },
       { code: 45, label: 'Fog' },
       { code: 48, label: 'Icy fog' },
+    ],
+  },
+  {
+    title: 'Night sky conditions',
+    icons: [
+      { code: 0,  label: 'Clear night',         isDay: false },
+      { code: 1,  label: 'Mainly clear night',   isDay: false },
+      { code: 2,  label: 'Partly cloudy night',  isDay: false },
+      { code: 3,  label: 'Overcast',             isDay: false },
     ],
   },
   {
@@ -69,6 +81,14 @@ const groups: IconGroup[] = [
     ],
   },
   {
+    title: 'Rain showers (night) — light → moderate → heavy',
+    icons: [
+      { code: 80, label: 'Showers',  intensity: 'light',    isDay: false },
+      { code: 81, label: 'Showers',  intensity: 'moderate', isDay: false },
+      { code: 82, label: 'Showers',  intensity: 'heavy',    isDay: false },
+    ],
+  },
+  {
     title: 'Snow — light → moderate → heavy',
     icons: [
       { code: 71, label: 'Snow',  intensity: 'light' },
@@ -82,6 +102,13 @@ const groups: IconGroup[] = [
     icons: [
       { code: 85, label: 'Snow showers',  intensity: 'light' },
       { code: 86, label: 'Snow showers',  intensity: 'heavy' },
+    ],
+  },
+  {
+    title: 'Snow showers (night) — light → heavy',
+    icons: [
+      { code: 85, label: 'Snow showers',  intensity: 'light', isDay: false },
+      { code: 86, label: 'Snow showers',  intensity: 'heavy', isDay: false },
     ],
   },
   {
@@ -102,6 +129,23 @@ const groups: IconGroup[] = [
     ],
   },
 ]
+
+// ── Moon phase entries ────────────────────────────────────────────────────────
+// All 8 named phases spread evenly across the synodic month (fractions 0–1).
+const moonPhases = [
+  { fraction: 0.00,  name: 'New Moon' },
+  { fraction: 0.125, name: 'Waxing Crescent' },
+  { fraction: 0.25,  name: 'First Quarter' },
+  { fraction: 0.375, name: 'Waxing Gibbous' },
+  { fraction: 0.50,  name: 'Full Moon' },
+  { fraction: 0.625, name: 'Waning Gibbous' },
+  { fraction: 0.75,  name: 'Last Quarter' },
+  { fraction: 0.875, name: 'Waning Crescent' },
+].map(({ fraction, name }) => ({
+  fraction,
+  name: getMoonPhaseName(fraction),   // derived — sanity-checks the label
+  icon: getMoonPhaseIcon(getMoonPhaseName(fraction)),
+}))
 </script>
 
 <template>
@@ -120,7 +164,7 @@ const groups: IconGroup[] = [
       <span class="text-xs text-slate-500 dark:text-slate-400">(not shown in production)</span>
     </div>
 
-    <!-- Groups -->
+    <!-- Weather icon groups -->
     <div class="flex flex-col gap-6">
       <div
         v-for="group in groups"
@@ -138,6 +182,7 @@ const groups: IconGroup[] = [
             <WeatherIcon
               :code="entry.code"
               :intensity="entry.intensity"
+              :is-day="entry.isDay"
               :size="40"
               :label="entry.label"
             />
@@ -149,6 +194,43 @@ const groups: IconGroup[] = [
               class="rounded-full bg-blue-100 px-1.5 py-0.5 text-[9px] font-medium text-blue-700 dark:bg-blue-900/40 dark:text-blue-300"
             >
               {{ entry.intensity }}
+            </span>
+            <span
+              v-if="entry.isDay === false"
+              class="rounded-full bg-slate-200 px-1.5 py-0.5 text-[9px] font-medium text-slate-600 dark:bg-slate-700 dark:text-slate-300"
+            >
+              night
+            </span>
+          </div>
+        </div>
+      </div>
+
+      <!-- Moon phases -->
+      <div>
+        <p class="mb-2 text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
+          Moon phases
+        </p>
+        <div class="flex flex-wrap gap-3">
+          <div
+            v-for="phase in moonPhases"
+            :key="phase.name"
+            class="flex flex-col items-center gap-1.5 rounded-xl bg-white/70 px-3 py-2.5 shadow-sm dark:bg-white/5"
+          >
+            <svg
+              width="40"
+              height="40"
+              viewBox="0 0 64 64"
+              fill="none"
+              xmlns="http://www.w3.org/2000/svg"
+              class="select-none shrink-0"
+              aria-hidden="true"
+              v-html="phase.icon"
+            />
+            <span class="max-w-[80px] text-center text-[10px] leading-tight text-slate-600 dark:text-slate-300">
+              {{ phase.name }}
+            </span>
+            <span class="rounded-full bg-slate-200 px-1.5 py-0.5 text-[9px] font-medium text-slate-500 dark:bg-slate-700 dark:text-slate-400">
+              {{ Math.round(phase.fraction * 100) }}%
             </span>
           </div>
         </div>

--- a/src/components/WeatherIconDemo.vue
+++ b/src/components/WeatherIconDemo.vue
@@ -41,10 +41,9 @@ const groups: IconGroup[] = [
   {
     title: 'Night sky conditions',
     icons: [
-      { code: 0,  label: 'Clear night',         isDay: false },
-      { code: 1,  label: 'Mainly clear night',   isDay: false },
-      { code: 2,  label: 'Partly cloudy night',  isDay: false },
-      { code: 3,  label: 'Overcast',             isDay: false },
+      { code: 0, label: 'Clear night',        isDay: false },
+      { code: 1, label: 'Mainly clear night',  isDay: false },
+      { code: 2, label: 'Partly cloudy night', isDay: false },
     ],
   },
   {

--- a/src/composables/useMoonPhase.ts
+++ b/src/composables/useMoonPhase.ts
@@ -1,0 +1,106 @@
+/**
+ * useMoonPhase
+ *
+ * Computes the current moon phase from the current date using the
+ * Julian Day Number method. No external API is required.
+ *
+ * The synodic month (new moon → new moon) is ~29.53059 days.
+ * Phase is expressed as a value 0–1 (0 = new moon, 0.5 = full moon).
+ *
+ * Returns:
+ *  - phaseFraction: 0–1 value representing where we are in the lunar cycle
+ *  - phaseName:     Human-readable phase label
+ *  - phaseIcon:     SVG markup for the moon phase icon
+ */
+
+export interface MoonPhaseInfo {
+  phaseFraction: number
+  phaseName: string
+  phaseIcon: string
+}
+
+/** Synodic month in days */
+const SYNODIC_MONTH = 29.53059
+
+/**
+ * Compute the moon phase fraction (0–1) for a given date.
+ * Uses the Julian Day Number approach relative to a known new moon.
+ * Reference new moon: 2000-01-06 18:14 UTC (JDN 2451550.259)
+ */
+export function getMoonPhaseFraction(date: Date = new Date()): number {
+  // Julian Day Number
+  const jd =
+    date.getTime() / 86400000 + 2440587.5
+  const daysSinceNew = (jd - 2451550.259) % SYNODIC_MONTH
+  const fraction = (daysSinceNew < 0 ? daysSinceNew + SYNODIC_MONTH : daysSinceNew) / SYNODIC_MONTH
+  return fraction
+}
+
+/**
+ * Map a phase fraction to a human-readable name.
+ * Uses 8 named phases covering the full cycle.
+ */
+export function getMoonPhaseName(fraction: number): string {
+  const p = fraction
+  if (p < 0.0625 || p >= 0.9375) return 'New Moon'
+  if (p < 0.1875) return 'Waxing Crescent'
+  if (p < 0.3125) return 'First Quarter'
+  if (p < 0.4375) return 'Waxing Gibbous'
+  if (p < 0.5625) return 'Full Moon'
+  if (p < 0.6875) return 'Waning Gibbous'
+  if (p < 0.8125) return 'Last Quarter'
+  return 'Waning Crescent'
+}
+
+// ---------------------------------------------------------------------------
+// SVG moon phase icons (viewBox 0 0 64 64)
+// ---------------------------------------------------------------------------
+// All icons use a dark-circle base (#1E293B, slate-800) with a light disc
+// (#E2E8F0, slate-200) to show the illuminated portion. Works in both
+// light and dark mode.
+
+const MOON_ICONS: Record<string, string> = {
+  'New Moon': `
+    <circle cx="32" cy="32" r="22" fill="#1E293B" stroke="#475569" stroke-width="1.5"/>`,
+
+  'Waxing Crescent': `
+    <circle cx="32" cy="32" r="22" fill="#1E293B" stroke="#475569" stroke-width="1.5"/>
+    <path d="M32 10 Q50 18 50 32 Q50 46 32 54 Q42 46 42 32 Q42 18 32 10 Z" fill="#E2E8F0"/>`,
+
+  'First Quarter': `
+    <circle cx="32" cy="32" r="22" fill="#1E293B" stroke="#475569" stroke-width="1.5"/>
+    <path d="M32 10 Q54 10 54 32 Q54 54 32 54 Z" fill="#E2E8F0"/>`,
+
+  'Waxing Gibbous': `
+    <circle cx="32" cy="32" r="22" fill="#E2E8F0"/>
+    <path d="M32 10 Q14 18 14 32 Q14 46 32 54 Q22 46 22 32 Q22 18 32 10 Z" fill="#1E293B"/>`,
+
+  'Full Moon': `
+    <circle cx="32" cy="32" r="22" fill="#E2E8F0" stroke="#CBD5E1" stroke-width="1"/>
+    <circle cx="26" cy="28" r="3" fill="#CBD5E1" opacity="0.5"/>
+    <circle cx="38" cy="36" r="4" fill="#CBD5E1" opacity="0.4"/>
+    <circle cx="30" cy="38" r="2" fill="#CBD5E1" opacity="0.35"/>`,
+
+  'Waning Gibbous': `
+    <circle cx="32" cy="32" r="22" fill="#E2E8F0"/>
+    <path d="M32 10 Q50 18 50 32 Q50 46 32 54 Q42 46 42 32 Q42 18 32 10 Z" fill="#1E293B"/>`,
+
+  'Last Quarter': `
+    <circle cx="32" cy="32" r="22" fill="#1E293B" stroke="#475569" stroke-width="1.5"/>
+    <path d="M32 10 Q10 10 10 32 Q10 54 32 54 Z" fill="#E2E8F0"/>`,
+
+  'Waning Crescent': `
+    <circle cx="32" cy="32" r="22" fill="#1E293B" stroke="#475569" stroke-width="1.5"/>
+    <path d="M32 10 Q14 18 14 32 Q14 46 32 54 Q22 46 22 32 Q22 18 32 10 Z" fill="#E2E8F0"/>`,
+}
+
+export function getMoonPhaseIcon(phaseName: string): string {
+  return MOON_ICONS[phaseName] ?? MOON_ICONS['New Moon']!
+}
+
+export function useMoonPhase(date?: Date): MoonPhaseInfo {
+  const phaseFraction = getMoonPhaseFraction(date)
+  const phaseName = getMoonPhaseName(phaseFraction)
+  const phaseIcon = getMoonPhaseIcon(phaseName)
+  return { phaseFraction, phaseName, phaseIcon }
+}

--- a/src/services/weatherService.ts
+++ b/src/services/weatherService.ts
@@ -152,7 +152,7 @@ export async function fetchDailyForecast(lat: number, lon: number): Promise<Dail
     latitude: String(lat),
     longitude: String(lon),
     daily:
-      'weather_code,temperature_2m_max,temperature_2m_min,precipitation_sum,precipitation_probability_max,precipitation_hours',
+      'weather_code,temperature_2m_max,temperature_2m_min,precipitation_sum,precipitation_probability_max,precipitation_hours,sunrise,sunset',
     timezone: 'auto',
   })
 
@@ -174,5 +174,7 @@ export async function fetchDailyForecast(lat: number, lon: number): Promise<Dail
     precipitationSum: d.precipitation_sum,
     precipitationProbabilityMax: d.precipitation_probability_max,
     precipitationHours: d.precipitation_hours ?? null,
+    sunrise: d.sunrise ?? null,
+    sunset: d.sunset ?? null,
   }
 }

--- a/src/services/weatherService.ts
+++ b/src/services/weatherService.ts
@@ -85,7 +85,7 @@ export async function fetchCurrentWeather(lat: number, lon: number): Promise<Cur
     latitude: String(lat),
     longitude: String(lon),
     current:
-      'temperature_2m,relative_humidity_2m,apparent_temperature,weather_code,wind_speed_10m,wind_direction_10m,precipitation',
+      'temperature_2m,relative_humidity_2m,apparent_temperature,weather_code,wind_speed_10m,wind_direction_10m,precipitation,is_day',
     timezone: 'auto',
   })
 
@@ -108,6 +108,7 @@ export async function fetchCurrentWeather(lat: number, lon: number): Promise<Cur
     windDirection: c.wind_direction_10m,
     time: c.time,
     precipitation: c.precipitation ?? null,
+    isDay: c.is_day !== undefined ? c.is_day === 1 : null,
   }
 }
 

--- a/src/services/weatherService.ts
+++ b/src/services/weatherService.ts
@@ -119,7 +119,7 @@ export async function fetchHourlyForecast(lat: number, lon: number): Promise<Hou
   const params = new URLSearchParams({
     latitude: String(lat),
     longitude: String(lon),
-    hourly: 'temperature_2m,precipitation_probability,precipitation,weather_code',
+    hourly: 'temperature_2m,precipitation_probability,precipitation,weather_code,is_day',
     timezone: 'auto',
     forecast_hours: '24',
   })
@@ -140,6 +140,7 @@ export async function fetchHourlyForecast(lat: number, lon: number): Promise<Hou
     precipitationProbability: h.precipitation_probability,
     precipitation: h.precipitation,
     weatherCode: h.weather_code,
+    isDay: h.is_day ?? null,
   }
 }
 

--- a/src/stores/weather.ts
+++ b/src/stores/weather.ts
@@ -29,6 +29,9 @@ function loadFromStorage(): WeatherCache | null {
       parsed.currentWeather.precipitation = parsed.currentWeather.precipitation ?? null
       parsed.currentWeather.isDay = parsed.currentWeather.isDay ?? null
     }
+    if (parsed.hourlyForecast) {
+      parsed.hourlyForecast.isDay = parsed.hourlyForecast.isDay ?? null
+    }
     if (parsed.dailyForecast) {
       parsed.dailyForecast.precipitationHours = parsed.dailyForecast.precipitationHours ?? null
     }

--- a/src/stores/weather.ts
+++ b/src/stores/weather.ts
@@ -27,6 +27,7 @@ function loadFromStorage(): WeatherCache | null {
     // rest of the app always receives a known type (number | null).
     if (parsed.currentWeather) {
       parsed.currentWeather.precipitation = parsed.currentWeather.precipitation ?? null
+      parsed.currentWeather.isDay = parsed.currentWeather.isDay ?? null
     }
     if (parsed.dailyForecast) {
       parsed.dailyForecast.precipitationHours = parsed.dailyForecast.precipitationHours ?? null

--- a/src/stores/weather.ts
+++ b/src/stores/weather.ts
@@ -34,6 +34,8 @@ function loadFromStorage(): WeatherCache | null {
     }
     if (parsed.dailyForecast) {
       parsed.dailyForecast.precipitationHours = parsed.dailyForecast.precipitationHours ?? null
+      parsed.dailyForecast.sunrise = parsed.dailyForecast.sunrise ?? null
+      parsed.dailyForecast.sunset = parsed.dailyForecast.sunset ?? null
     }
 
     return parsed

--- a/src/types/weather.ts
+++ b/src/types/weather.ts
@@ -167,6 +167,12 @@ export interface DailyForecast {
    * Null when the value is missing (e.g. older persisted cache shapes).
    */
   precipitationHours: number[] | null
+  /**
+   * ISO 8601 datetime strings for sunrise/sunset per day.
+   * Null when absent from older persisted cache shapes.
+   */
+  sunrise: string[] | null
+  sunset: string[] | null
 }
 
 /** Raw response shape from Open-Meteo /v1/forecast (daily fields only) */
@@ -184,6 +190,8 @@ export interface OpenMeteoDailyResponse {
     precipitation_probability_max: string
     /** Present only when precipitation_hours is requested */
     precipitation_hours?: string
+    sunrise?: string
+    sunset?: string
   }
   daily: {
     time: string[]
@@ -194,6 +202,8 @@ export interface OpenMeteoDailyResponse {
     precipitation_probability_max: number[]
     /** Absent in older cached shapes */
     precipitation_hours?: number[]
+    sunrise?: string[]
+    sunset?: string[]
   }
 }
 

--- a/src/types/weather.ts
+++ b/src/types/weather.ts
@@ -122,6 +122,8 @@ export interface HourlyForecast {
   precipitationProbability: number[]
   precipitation: number[]
   weatherCode: number[]
+  /** 1 = daytime, 0 = nighttime per hour. Null array when absent from older cached shapes. */
+  isDay: number[] | null
 }
 
 /** Raw response shape from Open-Meteo /v1/forecast (hourly fields) */
@@ -136,6 +138,7 @@ export interface OpenMeteoHourlyResponse {
     precipitation_probability: string
     precipitation: string
     weather_code: string
+    is_day?: string
   }
   hourly: {
     time: string[]
@@ -143,6 +146,7 @@ export interface OpenMeteoHourlyResponse {
     precipitation_probability: number[]
     precipitation: number[]
     weather_code: number[]
+    is_day?: number[]
   }
 }
 

--- a/src/types/weather.ts
+++ b/src/types/weather.ts
@@ -71,6 +71,8 @@ export interface OpenMeteoCurrentWeatherResponse {
     wind_direction_10m: string
     /** Present only when precipitation is requested */
     precipitation?: string
+    /** Present only when is_day is requested */
+    is_day?: string
   }
   current: {
     time: string
@@ -82,6 +84,8 @@ export interface OpenMeteoCurrentWeatherResponse {
     wind_direction_10m: number
     /** Precipitation amount in mm for the current hour; absent in older cached shapes */
     precipitation?: number
+    /** 1 = daytime, 0 = nighttime */
+    is_day?: number
   }
 }
 
@@ -100,6 +104,11 @@ export interface CurrentWeather {
    * Null when the value is missing (e.g. older persisted cache shapes).
    */
   precipitation: number | null
+  /**
+   * Whether it is currently daytime (true) or nighttime (false).
+   * Null when the value is missing (e.g. older persisted cache shapes).
+   */
+  isDay: boolean | null
 }
 
 // ---------------------------------------------------------------------------

--- a/src/utils/weatherCodes.ts
+++ b/src/utils/weatherCodes.ts
@@ -39,8 +39,11 @@ interface WeatherCodeMeta {
  */
 export type SvgIconKey =
   | 'clear-day'
+  | 'clear-night'
   | 'mostly-clear'
+  | 'mostly-clear-night'
   | 'partly-cloudy'
+  | 'partly-cloudy-night'
   | 'overcast'
   | 'fog'
   | 'drizzle-light'
@@ -52,6 +55,9 @@ export type SvgIconKey =
   | 'showers-light'
   | 'showers-moderate'
   | 'showers-heavy'
+  | 'showers-light-night'
+  | 'showers-moderate-night'
+  | 'showers-heavy-night'
   | 'freezing-drizzle-light'
   | 'freezing-drizzle-heavy'
   | 'freezing-rain-light'
@@ -61,6 +67,8 @@ export type SvgIconKey =
   | 'snow-heavy'
   | 'snow-showers-light'
   | 'snow-showers-heavy'
+  | 'snow-showers-light-night'
+  | 'snow-showers-heavy-night'
   | 'fog-icy'
   | 'thunderstorm'
   | 'thunderstorm-hail'
@@ -101,8 +109,23 @@ export const SVG_ICONS: Record<SvgIconKey, string> = {
       <line x1="18" y1="46" x2="14" y2="50"/>
     </g>`,
 
-  // ── Mainly clear ───────────────────────────────────────────────────────────
-  'mostly-clear': `
+  // ── Clear night ────────────────────────────────────────────────────────────
+  'clear-night': `
+    <path d="M38 12 Q24 14 20 28 Q16 44 30 50 Q44 56 54 44 Q46 46 40 40 Q28 34 30 22 Q32 12 38 12 Z" fill="#93C5FD"/>
+    <circle cx="50" cy="16" r="2" fill="#E2E8F0" opacity="0.8"/>
+    <circle cx="14" cy="22" r="1.5" fill="#E2E8F0" opacity="0.6"/>
+    <circle cx="10" cy="42" r="1.5" fill="#E2E8F0" opacity="0.7"/>
+    <circle cx="56" cy="34" r="1" fill="#E2E8F0" opacity="0.5"/>`,
+
+  // ── Mainly clear night ─────────────────────────────────────────────────────
+  'mostly-clear-night': `
+    <path d="M28 8 Q18 10 15 20 Q12 32 22 37 Q30 42 38 35 Q32 36 28 30 Q22 22 26 14 Q27 9 28 8 Z" fill="#93C5FD"/>
+    <path d="M36 40 Q36 30 44 30 Q42 24 36 24 Q34 18 27 20 Q22 14 16 20 Q10 20 10 28 Q10 40 20 40 Z" fill="#CBD5E1"/>`,
+
+  // ── Partly cloudy night ────────────────────────────────────────────────────
+  'partly-cloudy-night': `
+    <path d="M26 10 Q18 12 15 20 Q12 30 20 35 Q26 38 33 33 Q28 33 24 28 Q20 20 24 14 Q25 10 26 10 Z" fill="#93C5FD"/>
+    <path d="M42 46 Q42 34 51 34 Q49 27 42 27 Q40 20 32 22 Q26 15 19 22 Q12 22 12 31 Q12 46 24 46 Z" fill="#CBD5E1"/>`,
     <circle cx="26" cy="26" r="10" fill="#FBBF24"/>
     <g stroke="#FBBF24" stroke-width="2.5" stroke-linecap="round">
       <line x1="26" y1="6"  x2="26" y2="11"/>
@@ -232,6 +255,28 @@ export const SVG_ICONS: Record<SvgIconKey, string> = {
     <line x1="40" y1="46" x2="38" y2="54" stroke="#3B82F6" stroke-width="3" stroke-linecap="round"/>
     <line x1="48" y1="46" x2="46" y2="54" stroke="#3B82F6" stroke-width="3" stroke-linecap="round"/>`,
 
+  // ── Night showers (moon + cloud + drops) ──────────────────────────────────
+  'showers-light-night': `
+    <path d="M20 8 Q14 10 12 17 Q10 25 16 29 Q20 32 25 28 Q21 28 18 24 Q15 18 18 12 Q19 8 20 8 Z" fill="#93C5FD"/>
+    <path d="M50 40 Q50 30 57 30 Q55 23 49 23 Q47 17 40 19 Q35 13 28 19 Q22 19 22 27 Q22 40 33 40 Z" fill="#CBD5E1"/>
+    <line x1="30" y1="48" x2="28" y2="56" stroke="#60A5FA" stroke-width="2.5" stroke-linecap="round"/>
+    <line x1="40" y1="48" x2="38" y2="56" stroke="#60A5FA" stroke-width="2.5" stroke-linecap="round"/>`,
+
+  'showers-moderate-night': `
+    <path d="M20 8 Q14 10 12 17 Q10 25 16 29 Q20 32 25 28 Q21 28 18 24 Q15 18 18 12 Q19 8 20 8 Z" fill="#93C5FD"/>
+    <path d="M50 40 Q50 30 57 30 Q55 23 49 23 Q47 17 40 19 Q35 13 28 19 Q22 19 22 27 Q22 40 33 40 Z" fill="#94A3B8"/>
+    <line x1="28" y1="47" x2="26" y2="55" stroke="#60A5FA" stroke-width="2.5" stroke-linecap="round"/>
+    <line x1="38" y1="47" x2="36" y2="55" stroke="#60A5FA" stroke-width="2.5" stroke-linecap="round"/>
+    <line x1="48" y1="47" x2="46" y2="55" stroke="#60A5FA" stroke-width="2.5" stroke-linecap="round"/>`,
+
+  'showers-heavy-night': `
+    <path d="M20 8 Q14 10 12 17 Q10 25 16 29 Q20 32 25 28 Q21 28 18 24 Q15 18 18 12 Q19 8 20 8 Z" fill="#93C5FD"/>
+    <path d="M50 40 Q50 30 57 30 Q55 23 49 23 Q47 17 40 19 Q35 13 28 19 Q22 19 22 27 Q22 40 33 40 Z" fill="#64748B"/>
+    <line x1="24" y1="46" x2="22" y2="54" stroke="#3B82F6" stroke-width="3" stroke-linecap="round"/>
+    <line x1="32" y1="46" x2="30" y2="54" stroke="#3B82F6" stroke-width="3" stroke-linecap="round"/>
+    <line x1="40" y1="46" x2="38" y2="54" stroke="#3B82F6" stroke-width="3" stroke-linecap="round"/>
+    <line x1="48" y1="46" x2="46" y2="54" stroke="#3B82F6" stroke-width="3" stroke-linecap="round"/>`,
+
   // ── Freezing drizzle (WMO 56 = light, 57 = heavy) ────────────────────────
   // Short, fine strokes in ice-blue (#BAE6FD, length ≈5, stroke-width 1.5)
   // mirror the drizzle stroke language; terminal frozen circles mark the freeze
@@ -334,6 +379,26 @@ export const SVG_ICONS: Record<SvgIconKey, string> = {
       <line x1="8"  y1="8"  x2="11" y2="11"/>
       <line x1="32" y1="8"  x2="29" y2="11"/>
     </g>
+    <path d="M50 40 Q50 30 57 30 Q55 23 49 23 Q47 17 40 19 Q35 13 28 19 Q22 19 22 27 Q22 40 33 40 Z" fill="#64748B"/>
+    <g fill="#BAE6FD">
+      <circle cx="28" cy="48" r="3"/>
+      <circle cx="38" cy="48" r="3"/>
+      <circle cx="48" cy="48" r="3"/>
+      <circle cx="33" cy="57" r="3"/>
+      <circle cx="43" cy="57" r="3"/>
+    </g>`,
+
+  // ── Night snow showers (moon + cloud + snow) ───────────────────────────────
+  'snow-showers-light-night': `
+    <path d="M20 8 Q14 10 12 17 Q10 25 16 29 Q20 32 25 28 Q21 28 18 24 Q15 18 18 12 Q19 8 20 8 Z" fill="#93C5FD"/>
+    <path d="M50 40 Q50 30 57 30 Q55 23 49 23 Q47 17 40 19 Q35 13 28 19 Q22 19 22 27 Q22 40 33 40 Z" fill="#CBD5E1"/>
+    <g fill="#BAE6FD">
+      <circle cx="30" cy="50" r="3"/>
+      <circle cx="42" cy="50" r="3"/>
+    </g>`,
+
+  'snow-showers-heavy-night': `
+    <path d="M20 8 Q14 10 12 17 Q10 25 16 29 Q20 32 25 28 Q21 28 18 24 Q15 18 18 12 Q19 8 20 8 Z" fill="#93C5FD"/>
     <path d="M50 40 Q50 30 57 30 Q55 23 49 23 Q47 17 40 19 Q35 13 28 19 Q22 19 22 27 Q22 40 33 40 Z" fill="#64748B"/>
     <g fill="#BAE6FD">
       <circle cx="28" cy="48" r="3"/>
@@ -468,21 +533,45 @@ const SVG_INTENSITY_OVERRIDE: Record<number, IntensityIconMap> = {
 }
 
 /**
+ * Night-mode overrides: WMO codes whose base daytime icon contains a sun
+ * are mapped to the equivalent night variant when `isDay === false`.
+ *
+ * Rain, drizzle, snow, and fog icons are neutral (no sun) and need no
+ * night override — only clear-sky and shower codes change.
+ */
+const NIGHT_KEY_MAP: Partial<Record<SvgIconKey, SvgIconKey>> = {
+  'clear-day':           'clear-night',
+  'mostly-clear':        'mostly-clear-night',
+  'partly-cloudy':       'partly-cloudy-night',
+  'showers-light':       'showers-light-night',
+  'showers-moderate':    'showers-moderate-night',
+  'showers-heavy':       'showers-heavy-night',
+  'snow-showers-light':  'snow-showers-light-night',
+  'snow-showers-heavy':  'snow-showers-heavy-night',
+}
+
+/**
  * Return the SVG icon markup (inner `<svg>` content) for `code`, optionally
- * biased by an intensity hint.
+ * biased by an intensity hint and day/night state.
  *
  * For codes that support intensity differentiation (rain, drizzle, snow,
  * showers) the returned SVG may differ from the base icon when `intensity`
  * is provided. For all other codes (clear, clouds, fog, thunderstorms,
  * freezing precipitation) the base icon is returned unchanged.
  *
+ * When `isDay` is explicitly `false`, sun-bearing icons (clear, partly
+ * cloudy, showers) are replaced with their night equivalents.
+ *
  * @param code      WMO weather code
  * @param intensity Optional severity hint (`'light' | 'moderate' | 'heavy'`).
  *                  Omit (or pass `undefined`) to use the code's natural icon.
+ * @param isDay     Pass `false` to use night icon variants. `true` or omitted
+ *                  keeps the default daytime icon.
  */
 export function getWeatherSvgIcon(
   code: number,
   intensity?: WeatherIntensity,
+  isDay?: boolean | null,
 ): string {
   let key: SvgIconKey
   if (intensity !== undefined) {
@@ -490,6 +579,10 @@ export function getWeatherSvgIcon(
     key = override ? override[intensity] : lookup(code).svgKey
   } else {
     key = lookup(code).svgKey
+  }
+  // Apply night substitution if it's explicitly nighttime
+  if (isDay === false) {
+    key = NIGHT_KEY_MAP[key] ?? key
   }
   return SVG_ICONS[key]
 }

--- a/src/utils/weatherCodes.ts
+++ b/src/utils/weatherCodes.ts
@@ -126,6 +126,9 @@ export const SVG_ICONS: Record<SvgIconKey, string> = {
   'partly-cloudy-night': `
     <path d="M26 10 Q18 12 15 20 Q12 30 20 35 Q26 38 33 33 Q28 33 24 28 Q20 20 24 14 Q25 10 26 10 Z" fill="#93C5FD"/>
     <path d="M42 46 Q42 34 51 34 Q49 27 42 27 Q40 20 32 22 Q26 15 19 22 Q12 22 12 31 Q12 46 24 46 Z" fill="#CBD5E1"/>`,
+
+  // ── Mainly clear ───────────────────────────────────────────────────────────
+  'mostly-clear': `
     <circle cx="26" cy="26" r="10" fill="#FBBF24"/>
     <g stroke="#FBBF24" stroke-width="2.5" stroke-linecap="round">
       <line x1="26" y1="6"  x2="26" y2="11"/>


### PR DESCRIPTION
## Summary

Implements all items from issue #5 plus an additional sunrise/sunset tile.

## Changes

### Issue #5 — Night improvements
- **Night icons**: `is_day` fetched from Open-Meteo for current + hourly data. 8 SVG night icon variants added (`clear-night`, `mainly-clear-night`, `partly-cloudy-night`, rain/snow showers night variants). `getWeatherSvgIcon()` accepts an `isDay` param and maps to night variants via `NIGHT_KEY_MAP`. The hero icon and each hourly forecast card now reflect day/night correctly.
- **Moon phase tile**: `useMoonPhase` composable added (pure astronomical calculation, no API). Displays phase name and SVG icon in a 4th box in the 2×2 stats grid.
- **Auto-refresh on stale data**: `visibilitychange` listener in `App.vue` calls `refreshAll()` if `lastUpdated` is >30 min old when the tab becomes visible.
- **SVG stat icons**: Replaced emoji (🌡️💧💨) in the stats grid with inline SVG icons (thermometer, water-drop, wind).

### Bonus — Sunrise / Sunset tile
- `sunrise` and `sunset` daily fields added to the Open-Meteo fetch, types, store cache normaliser, and `DailyForecast` interface.
- A full-width tile below the stats grid shows today's sunrise (amber) and sunset (orange) times formatted as `HH:MM` using the Dutch locale, hidden gracefully when data is unavailable.

## Type-check
`bun run type-check` passes clean.