### PR TITLE
feat(ui): restyle current weather experience

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -223,8 +223,8 @@ watch(
           </template>
           <template v-else>
             <div class="min-w-0">
-              <span class="block text-[11px] uppercase tracking-[0.24em] text-storm-water-500 dark:text-sea-mist-300/70">North Sea forecast</span>
-              <span class="block truncate font-display text-xl leading-tight text-storm-water-800 dark:text-dune-foam">{{ locationStore.cityName }}</span>
+              <span class="block text-[11px] uppercase tracking-[0.24em] text-storm-water-500 dark:text-sea-mist-300/70">Forecast</span>
+              <span class="block truncate text-lg font-semibold leading-tight text-storm-water-800 dark:text-dune-foam">{{ locationStore.cityName }}</span>
             </div>
             <button
               class="flex size-9 items-center justify-center rounded-full border border-slate-300 bg-slate-50 text-storm-water-600 transition-colors hover:bg-slate-100 hover:text-storm-water-800 dark:border-slate-600 dark:bg-[#22313d] dark:text-sea-mist-300 dark:hover:bg-[#2a3a47] dark:hover:text-white"

--- a/src/App.vue
+++ b/src/App.vue
@@ -41,11 +41,6 @@ const themeLabel = computed(() => {
   if (themeStore.theme === 'light') return 'Switch to system theme'
   return 'Switch to dark mode'
 })
-const themeIcon = computed(() => {
-  if (themeStore.theme === 'dark') return '☀️'
-  if (themeStore.theme === 'light') return '🌙'
-  return '⚙️'
-})
 
 // ── Stale data auto-refresh ──────────────────────────────────────────────────
 const STALE_THRESHOLD_MS = 30 * 60 * 1000 // 30 minutes
@@ -133,12 +128,12 @@ watch(
 </script>
 
 <template>
-  <div class="min-h-dvh text-slate-800 dark:text-white">
+  <div class="min-h-dvh text-storm-water-800 dark:text-slate-50">
     <!-- Pull-to-refresh indicator -->
     <Transition name="ptr">
       <div
         v-if="isPulling || isRefreshing"
-        class="flex items-center justify-center py-3 text-sm text-blue-600 dark:text-blue-300"
+        class="flex items-center justify-center py-3 text-sm text-storm-water-700 dark:text-sea-mist-200"
         :style="{ opacity: isRefreshing ? 1 : pullProgress }"
       >
         <svg
@@ -165,7 +160,7 @@ watch(
     <Transition name="slide-down">
       <div
         v-if="!isOnline"
-        class="flex items-center justify-center gap-2 bg-amber-500/90 px-4 py-2.5 text-center text-sm font-medium text-amber-950 backdrop-blur-sm"
+        class="flex items-center justify-center gap-2 border-b border-white/30 bg-gradient-to-r from-[#c7924b]/90 via-[#d6aa70]/90 to-[#c68a46]/90 px-4 py-2.5 text-center text-sm font-medium text-[#2f2316] backdrop-blur-sm"
         role="status"
         aria-live="polite"
       >
@@ -190,17 +185,21 @@ watch(
     </Transition>
 
     <!-- Compact header bar — sticky, full-width, with inner centering -->
-    <header class="sticky top-0 z-40 bg-sky-100 dark:bg-[#0f2027] backdrop-blur-md border-b border-slate-300/50 dark:border-white/10">
-      <div class="mx-auto w-full max-w-lg px-4 md:max-w-2xl pb-2 pt-safe pt-4">
+    <header class="sticky top-0 z-40 border-b border-slate-300/80 bg-[#f4f7f8]/96 backdrop-blur-md dark:border-slate-700 dark:bg-[#17222b]/96">
+      <div class="mx-auto w-full max-w-lg px-4 md:max-w-2xl pb-3 pt-safe pt-4">
         <!-- Header row -->
-        <div class="flex items-center gap-2">
-          <!-- Brand emoji -->
-          <span class="text-xl" aria-hidden="true">🌤️</span>
+        <div class="flex items-center gap-3 rounded-[1.2rem] border border-slate-300 bg-white px-3 py-2.5 shadow-[0_8px_24px_rgba(36,48,57,0.05)] dark:border-slate-700 dark:bg-[#1b2731] dark:shadow-none">
+          <span class="flex size-10 items-center justify-center rounded-full border border-slate-300 bg-slate-50 text-storm-water-700 dark:border-slate-600 dark:bg-[#22313d] dark:text-dune-foam" aria-hidden="true">
+            <svg class="size-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M4 15.5A4.5 4.5 0 0 1 8.5 11H9a5 5 0 1 1 9.7 1.8A3.5 3.5 0 1 1 18 19H8a4 4 0 0 1-4-3.5Z" />
+              <path d="M8 19l1.2-2.1M12 19l1.2-2.1M16 19l1.2-2.1" />
+            </svg>
+          </span>
 
           <!-- Location: detecting state or city name + edit button -->
           <template v-if="geoLoading">
             <svg
-              class="size-4 animate-spin text-blue-600 dark:text-blue-200"
+              class="size-4 animate-spin text-storm-water-700 dark:text-sea-mist-200"
               xmlns="http://www.w3.org/2000/svg"
               fill="none"
               viewBox="0 0 24 24"
@@ -220,12 +219,15 @@ watch(
                 d="M4 12a8 8 0 0 1 8-8V0C5.373 0 0 5.373 0 12h4z"
               />
             </svg>
-            <span class="text-sm text-blue-600 dark:text-blue-200">Detecting…</span>
+            <span class="text-sm text-storm-water-700 dark:text-sea-mist-200">Detecting…</span>
           </template>
           <template v-else>
-            <span class="text-sm font-semibold text-slate-800 dark:text-white">{{ locationStore.cityName }}</span>
+            <div class="min-w-0">
+              <span class="block text-[11px] uppercase tracking-[0.24em] text-storm-water-500 dark:text-sea-mist-300/70">North Sea forecast</span>
+              <span class="block truncate font-display text-xl leading-tight text-storm-water-800 dark:text-dune-foam">{{ locationStore.cityName }}</span>
+            </div>
             <button
-              class="flex size-8 items-center justify-center rounded-full text-blue-600/60 dark:text-blue-200/60 transition-colors hover:bg-black/5 dark:hover:bg-white/10 hover:text-slate-800 dark:hover:text-white"
+              class="flex size-9 items-center justify-center rounded-full border border-slate-300 bg-slate-50 text-storm-water-600 transition-colors hover:bg-slate-100 hover:text-storm-water-800 dark:border-slate-600 dark:bg-[#22313d] dark:text-sea-mist-300 dark:hover:bg-[#2a3a47] dark:hover:text-white"
               aria-label="Change location"
               @click="isEditingLocation = !isEditingLocation"
             >
@@ -249,24 +251,64 @@ watch(
           <!-- Right side: last updated + theme toggle + refresh -->
           <div class="ml-auto flex items-center gap-1">
             <Transition name="fade">
-              <span v-if="isOnline && lastUpdatedLabel" class="text-xs text-blue-600/60 dark:text-blue-300/60">
+              <span v-if="isOnline && lastUpdatedLabel" class="hidden text-[11px] tracking-wide text-storm-water-500 md:inline dark:text-sea-mist-300/60">
                 Last updated {{ lastUpdatedLabel }}
               </span>
             </Transition>
 
             <!-- Theme toggle button — cycles dark → light → system -->
             <button
-              class="flex size-8 items-center justify-center rounded-full text-blue-600/60 dark:text-blue-200/60 transition-colors hover:bg-black/5 dark:hover:bg-white/10 hover:text-slate-800 dark:hover:text-white active:bg-black/10 dark:active:bg-white/20"
+              class="flex size-9 items-center justify-center rounded-full border border-slate-300 bg-slate-50 text-storm-water-600 transition-colors hover:bg-slate-100 hover:text-storm-water-800 active:bg-slate-100 dark:border-slate-600 dark:bg-[#22313d] dark:text-sea-mist-300 dark:hover:bg-[#2a3a47] dark:hover:text-white dark:active:bg-[#2a3a47]"
               :title="themeLabel"
               :aria-label="themeLabel"
               @click="cycleTheme"
             >
-              <span class="text-sm leading-none" aria-hidden="true">{{ themeIcon }}</span>
+              <svg
+                v-if="themeStore.theme === 'dark'"
+                class="size-4"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="1.8"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                aria-hidden="true"
+              >
+                <circle cx="12" cy="12" r="4" />
+                <path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41" />
+              </svg>
+              <svg
+                v-else-if="themeStore.theme === 'light'"
+                class="size-4"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="1.8"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                aria-hidden="true"
+              >
+                <path d="M21 12.79A9 9 0 1 1 11.21 3c0 5 4 9 9 9 .27 0 .53-.01.79-.05Z" />
+              </svg>
+              <svg
+                v-else
+                class="size-4"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="1.8"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                aria-hidden="true"
+              >
+                <circle cx="12" cy="12" r="3" />
+                <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06A1.65 1.65 0 0 0 15 19.4a1.65 1.65 0 0 0-1 1.5V21a2 2 0 1 1-4 0v-.09a1.65 1.65 0 0 0-1-1.52 1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.6 15a1.65 1.65 0 0 0-1.5-1H3a2 2 0 1 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.6a1.65 1.65 0 0 0 1-1.5V3a2 2 0 1 1 4 0v.09A1.65 1.65 0 0 0 15 4.6a1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9c0 .66.39 1.26 1 1.5H21a2 2 0 1 1 0 4h-.09c-.61.24-1.01.84-1.51 1.5Z" />
+              </svg>
             </button>
 
             <!-- Refresh button — min 44px tap target -->
             <button
-              class="flex size-8 items-center justify-center rounded-full text-blue-600/60 dark:text-blue-200/60 transition-colors hover:bg-black/5 dark:hover:bg-white/10 hover:text-slate-800 dark:hover:text-white active:bg-black/10 dark:active:bg-white/20 disabled:opacity-40"
+              class="flex size-9 items-center justify-center rounded-full border border-slate-300 bg-slate-50 text-storm-water-600 transition-colors hover:bg-slate-100 hover:text-storm-water-800 active:bg-slate-100 disabled:opacity-40 dark:border-slate-600 dark:bg-[#22313d] dark:text-sea-mist-300 dark:hover:bg-[#2a3a47] dark:hover:text-white dark:active:bg-[#2a3a47]"
               :disabled="isLoading"
               :title="isLoading ? 'Refreshing…' : 'Refresh weather data'"
               aria-label="Refresh weather data"
@@ -294,7 +336,7 @@ watch(
 
         <!-- Search row: visible when editing -->
         <Transition name="fade">
-          <div v-if="isEditingLocation" class="mt-2">
+          <div v-if="isEditingLocation" class="mt-3">
             <LocationSearch
               @select="isEditingLocation = false"
               @cancel="isEditingLocation = false"
@@ -304,7 +346,7 @@ watch(
 
         <!-- Geolocation error notice -->
         <Transition name="fade">
-          <p v-if="geoError" class="mt-2 text-xs text-yellow-600 dark:text-yellow-300">
+          <p v-if="geoError" class="mt-3 text-xs text-[#7a5422] dark:text-[#e7c48b]">
             {{ geoError }}
           </p>
         </Transition>
@@ -314,7 +356,7 @@ watch(
     <!-- Page shell: centred column, mobile-first -->
     <div class="mx-auto w-full max-w-lg px-4 md:max-w-2xl">
       <!-- Main content: each component fills the column width -->
-      <main class="mt-6 flex flex-col gap-5 pb-safe">
+      <main class="mt-7 flex flex-col gap-6 pb-safe md:mt-8 md:gap-7">
         <Transition name="content-fade" appear>
           <CurrentWeather @open-radar="openRadar" />
         </Transition>

--- a/src/components/CurrentWeather.vue
+++ b/src/components/CurrentWeather.vue
@@ -37,12 +37,66 @@ const temperature = computed(() =>
 const feelsLike = computed(() =>
   weather.value !== null ? Math.round(weather.value.apparentTemperature) : null,
 )
-const description = computed(() =>
-  weather.value !== null ? getWeatherDescription(weather.value.weatherCode) : '',
-)
 const windCompass = computed(() =>
   weather.value !== null ? degreesToCompass(weather.value.windDirection) : '',
 )
+const todayMaxTemp = computed(() =>
+  daily.value?.temperatureMax?.[0] != null ? Math.round(daily.value.temperatureMax[0]) : null,
+)
+const todayMinTemp = computed(() =>
+  daily.value?.temperatureMin?.[0] != null ? Math.round(daily.value.temperatureMin[0]) : null,
+)
+const todayPrecipProb = computed(() => daily.value?.precipitationProbabilityMax?.[0] ?? null)
+const todayPrecipHours = computed(() => daily.value?.precipitationHours?.[0] ?? null)
+const todayPrecipSum = computed(() => daily.value?.precipitationSum?.[0] ?? null)
+const todayCondition = computed(() =>
+  weather.value !== null ? getWeatherDescription(weather.value.weatherCode) : '',
+)
+
+const humidityRainDetail = computed(() => {
+  const precip = todayPrecipSum.value
+  if (precip == null) return ''
+  if (precip < 0.1) return 'No rain expected'
+  if (precip < 1) return `${precip.toFixed(1)} mm expected`
+  return `${Math.round(precip * 10) / 10} mm expected`
+})
+
+const windSummary = computed(() => {
+  const speed = weather.value?.windSpeed
+  if (speed == null) return ''
+  const tone = speed < 8 ? 'Calm' : speed < 18 ? 'Light breeze' : speed < 28 ? 'Breezy' : 'Windy'
+  return `${tone} ${windCompass.value}`
+})
+
+const rainSummary = computed(() => {
+  const mins = precipStore.minutesUntilRain
+  if (mins === null) {
+    if ((todayPrecipProb.value ?? 0) >= 45) return 'Showers possible later'
+    return 'Mostly dry today'
+  }
+  if (mins === 0) return `${rainIntensityLabel.value} now`
+  return `${rainIntensityLabel.value} in ${mins} min`
+})
+
+const todayOutlook = computed(() => {
+  const condition = todayCondition.value
+  const precipProb = todayPrecipProb.value ?? 0
+  const precipHours = todayPrecipHours.value ?? 0
+  const max = todayMaxTemp.value
+  const min = todayMinTemp.value
+  const wind = windSummary.value.toLowerCase()
+
+  let rainPhrase = 'staying mostly dry'
+  if (precipProb >= 70 && precipHours >= 4) rainPhrase = 'with rain likely for much of the day'
+  else if (precipProb >= 55) rainPhrase = 'with showers likely later on'
+  else if (precipProb >= 30) rainPhrase = 'with a slight chance of rain later'
+
+  let rangePhrase = ''
+  if (max !== null && min !== null) rangePhrase = `High ${max}°, low ${min}°.`
+  else if (max !== null) rangePhrase = `High near ${max}°.`
+
+  return `${condition}, ${wind}, ${rainPhrase}. ${rangePhrase}`.replace(/\s+/g, ' ').trim()
+})
 
 // ── Current-hour icon intensity ──────────────────────────────────────────────
 
@@ -227,33 +281,33 @@ const gridLines = computed(() => {
     />
 
     <div class="relative z-10 p-6">
-      <!-- Top row: temperature + big icon -->
-      <div class="mb-3 flex items-start justify-between gap-4">
-        <!-- Temperature -->
-        <div>
-          <p class="mb-2 text-[11px] uppercase tracking-[0.28em] text-storm-water-500 dark:text-sea-mist-300/70">Current conditions</p>
-          <div class="flex items-start leading-none">
-            <span data-display="true" class="font-display text-[5rem] font-medium tracking-[-0.06em] text-storm-water-800 dark:text-dune-foam">
-              {{ temperature }}
-            </span>
-            <span class="mt-3 text-3xl font-light text-storm-water-500 dark:text-sea-mist-200/80">°C</span>
+      <!-- Hero overview -->
+      <div class="mb-4 grid gap-4 sm:grid-cols-[minmax(0,0.6fr)_minmax(0,1.15fr)_auto] sm:items-center">
+        <div class="min-w-0 sm:self-center">
+          <div class="min-w-0">
+            <div class="flex items-start gap-1 leading-none">
+              <span data-display="true" class="font-display text-[4.5rem] font-medium tracking-[-0.05em] text-storm-water-800 dark:text-dune-foam sm:text-[4.75rem]">
+                {{ temperature }}
+              </span>
+              <span class="mt-2.5 text-[1.7rem] font-normal text-storm-water-500 dark:text-sea-mist-200/80">°C</span>
+            </div>
           </div>
         </div>
 
-        <!-- Weather icon (large) -->
+        <div class="px-1 py-1 sm:self-center">
+          <p class="mb-2 text-[10px] uppercase tracking-[0.3em] text-storm-water-500 dark:text-sea-mist-300/70">
+            {{ todayOutlook }}
+          </p>
+        </div>
+
         <WeatherIcon
           :code="weather.weatherCode"
           :intensity="currentWeatherIntensity"
           :is-day="weather.isDay"
-          :size="64"
-          class="mt-1 rounded-full border border-slate-300 bg-slate-50 p-2 transition-all duration-300 dark:border-slate-600 dark:bg-[#22313d]"
+          :size="78"
+          class="self-center justify-self-start transition-all duration-300 sm:justify-self-end"
         />
       </div>
-
-      <!-- Description -->
-      <p class="mb-6 max-w-[14rem] text-lg font-medium text-storm-water-700 dark:text-dune-foam/92">
-        {{ description }}
-      </p>
 
       <!-- Stats grid -->
       <div class="grid grid-cols-2 gap-3">
@@ -265,7 +319,13 @@ const gridLines = computed(() => {
             <path d="M14 14.76V3.5a2.5 2.5 0 0 0-5 0v11.26a4.5 4.5 0 1 0 5 0Z"/>
           </svg>
           <span class="text-xs font-medium uppercase tracking-[0.18em] text-storm-water-500 dark:text-sea-mist-300/65">Feels like</span>
-          <span class="text-base font-semibold text-storm-water-800 dark:text-dune-foam">{{ feelsLike }}°C</span>
+          <span class="text-[15px] font-semibold text-storm-water-800 dark:text-dune-foam">{{ feelsLike }}°C</span>
+          <span
+            v-if="todayMaxTemp !== null && todayMinTemp !== null"
+            class="text-[11px] text-storm-water-500 dark:text-sea-mist-300/65"
+          >
+            H {{ todayMaxTemp }}° / L {{ todayMinTemp }}°
+          </span>
         </div>
 
         <!-- Humidity -->
@@ -276,7 +336,13 @@ const gridLines = computed(() => {
             <path d="M12 2.69l5.66 5.66a8 8 0 1 1-11.31 0Z"/>
           </svg>
           <span class="text-xs font-medium uppercase tracking-[0.18em] text-storm-water-500 dark:text-sea-mist-300/65">Humidity</span>
-          <span class="text-base font-semibold text-storm-water-800 dark:text-dune-foam">{{ weather.humidity }}%</span>
+          <span class="text-[15px] font-semibold text-storm-water-800 dark:text-dune-foam">{{ weather.humidity }}%</span>
+          <span
+            v-if="humidityRainDetail"
+            class="text-[11px] text-storm-water-500 dark:text-sea-mist-300/65"
+          >
+            {{ humidityRainDetail }}
+          </span>
         </div>
 
         <!-- Wind -->
@@ -287,11 +353,11 @@ const gridLines = computed(() => {
             <path d="M9.59 4.59A2 2 0 1 1 11 8H2m10.59 11.41A2 2 0 1 0 14 16H2m15.73-8.27A2.5 2.5 0 1 1 19.5 12H2"/>
           </svg>
           <span class="text-xs font-medium uppercase tracking-[0.18em] text-storm-water-500 dark:text-sea-mist-300/65">Wind</span>
-          <span class="text-base font-semibold text-storm-water-800 dark:text-dune-foam">
+          <span class="text-[15px] font-semibold text-storm-water-800 dark:text-dune-foam">
             {{ Math.round(weather.windSpeed) }}
             <span class="text-xs font-normal text-storm-water-500 dark:text-sea-mist-300/70">km/h</span>
+            {{ windCompass }}
           </span>
-          <span class="text-xs text-storm-water-500 dark:text-sea-mist-300/65">{{ windCompass }}</span>
         </div>
 
         <!-- Moon phase -->
@@ -300,7 +366,7 @@ const gridLines = computed(() => {
         >
           <svg class="size-5 shrink-0" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" v-html="moonPhase.phaseIcon" />
           <span class="text-xs font-medium uppercase tracking-[0.18em] text-storm-water-500 dark:text-sea-mist-300/65">Moon</span>
-          <span class="text-base font-semibold leading-tight text-storm-water-800 dark:text-dune-foam">{{ moonPhase.phaseName }}</span>
+          <span class="text-[15px] font-semibold leading-tight text-storm-water-800 dark:text-dune-foam">{{ moonPhase.phaseName }}</span>
         </div>
       </div>
 
@@ -319,7 +385,7 @@ const gridLines = computed(() => {
           </svg>
           <div class="text-center">
             <p class="text-xs font-medium uppercase tracking-[0.18em] text-storm-water-500 dark:text-sea-mist-300/65">Sunrise</p>
-            <p class="text-base font-semibold text-storm-water-800 dark:text-dune-foam">{{ todaySunrise }}</p>
+            <p class="text-[15px] font-semibold text-storm-water-800 dark:text-dune-foam">{{ todaySunrise }}</p>
           </div>
         </div>
 
@@ -337,7 +403,7 @@ const gridLines = computed(() => {
           </svg>
           <div class="text-center">
             <p class="text-xs font-medium uppercase tracking-[0.18em] text-storm-water-500 dark:text-sea-mist-300/65">Sunset</p>
-            <p class="text-base font-semibold text-storm-water-800 dark:text-dune-foam">{{ todaySunset }}</p>
+            <p class="text-[15px] font-semibold text-storm-water-800 dark:text-dune-foam">{{ todaySunset }}</p>
           </div>
         </div>
       </div>

--- a/src/components/CurrentWeather.vue
+++ b/src/components/CurrentWeather.vue
@@ -88,11 +88,11 @@ function barHeightPercent(mmPerHour: number): number {
 
 /** Color class for a precipitation bar based on intensity */
 function barColorClass(mmPerHour: number): string {
-  if (mmPerHour <= 0) return 'bg-slate-200 dark:bg-white/10'
-  if (mmPerHour < 0.5) return 'bg-blue-300/60 dark:bg-blue-300/50'   // drizzle
-  if (mmPerHour <= 2.5) return 'bg-blue-400/80 dark:bg-blue-400/70'  // light
-  if (mmPerHour <= 7.6) return 'bg-blue-600/85 dark:bg-blue-500/80'  // moderate
-  return 'bg-purple-500/90 dark:bg-purple-400/85'                     // heavy
+  if (mmPerHour <= 0) return 'bg-storm-water-200/50 dark:bg-white/10'
+  if (mmPerHour < 0.5) return 'bg-[#adc2cf]/80 dark:bg-[#8ea8b7]/55'   // drizzle
+  if (mmPerHour <= 2.5) return 'bg-[#7e9eb1]/85 dark:bg-[#6b8a9d]/75'  // light
+  if (mmPerHour <= 7.6) return 'bg-storm-water-600/85 dark:bg-storm-water-500/80'  // moderate
+  return 'bg-[#d19a5f]/90 dark:bg-[#c88a47]/85'                        // heavy
 }
 
 /** Describes the intensity of the first upcoming rain */
@@ -163,7 +163,7 @@ const gridLines = computed(() => {
   <!-- ------------------------------------------------------------------ -->
   <div
     v-if="loading && !weather"
-    class="w-full max-w-md overflow-hidden rounded-3xl border border-slate-300/50 dark:border-white/20 bg-slate-100 dark:bg-white/10 shadow-2xl backdrop-blur-md"
+    class="surface-hero w-full max-w-md overflow-hidden"
     aria-busy="true"
     aria-label="Loading weather data"
   >
@@ -201,7 +201,7 @@ const gridLines = computed(() => {
   <!-- ------------------------------------------------------------------ -->
   <div
     v-else-if="error && !weather"
-    class="w-full max-w-md overflow-hidden rounded-3xl border border-red-400/30 bg-red-500/20 p-6 shadow-2xl backdrop-blur-md"
+    class="w-full max-w-md overflow-hidden rounded-hero border border-[#a96f61]/30 bg-[#b97a6a]/18 p-6 shadow-mist backdrop-blur-xl dark:border-[#dca293]/20 dark:bg-[#7d4c42]/18 dark:shadow-storm"
     role="alert"
   >
     <div class="flex items-start gap-3">
@@ -218,24 +218,25 @@ const gridLines = computed(() => {
   <!-- ------------------------------------------------------------------ -->
   <div
     v-else-if="weather"
-    class="w-full max-w-md overflow-hidden rounded-3xl border border-slate-300/50 dark:border-white/20 bg-gradient-to-br from-white/70 via-white/60 to-white/50 dark:from-slate-700/40 dark:via-slate-800/30 dark:to-slate-900/20 shadow-2xl backdrop-blur-md transition-all duration-500"
+    class="surface-hero relative w-full max-w-md overflow-hidden transition-all duration-500"
   >
     <!-- Subtle loading bar when refreshing -->
     <div
       v-if="loading"
-      class="h-0.5 w-full animate-pulse bg-gradient-to-r from-transparent via-slate-400/60 dark:via-white/60 to-transparent"
+      class="relative z-10 h-0.5 w-full animate-pulse bg-gradient-to-r from-transparent via-storm-water-500/50 to-transparent dark:via-sea-mist-300/50"
     />
 
-    <div class="p-6">
+    <div class="relative z-10 p-6">
       <!-- Top row: temperature + big icon -->
-      <div class="mb-2 flex items-start justify-between">
+      <div class="mb-3 flex items-start justify-between gap-4">
         <!-- Temperature -->
         <div>
+          <p class="mb-2 text-[11px] uppercase tracking-[0.28em] text-storm-water-500 dark:text-sea-mist-300/70">Current conditions</p>
           <div class="flex items-start leading-none">
-            <span class="text-7xl font-thin tracking-tighter drop-shadow-lg">
+            <span data-display="true" class="font-display text-[5rem] font-medium tracking-[-0.06em] text-storm-water-800 dark:text-dune-foam">
               {{ temperature }}
             </span>
-            <span class="mt-3 text-3xl font-light text-slate-600 dark:text-white/80">°C</span>
+            <span class="mt-3 text-3xl font-light text-storm-water-500 dark:text-sea-mist-200/80">°C</span>
           </div>
         </div>
 
@@ -245,12 +246,12 @@ const gridLines = computed(() => {
           :intensity="currentWeatherIntensity"
           :is-day="weather.isDay"
           :size="64"
-          class="drop-shadow-md transition-all duration-300"
+          class="mt-1 rounded-full border border-slate-300 bg-slate-50 p-2 transition-all duration-300 dark:border-slate-600 dark:bg-[#22313d]"
         />
       </div>
 
       <!-- Description -->
-      <p class="mb-6 text-lg font-medium text-slate-700 dark:text-white/90">
+      <p class="mb-6 max-w-[14rem] text-lg font-medium text-storm-water-700 dark:text-dune-foam/92">
         {{ description }}
       </p>
 
@@ -258,55 +259,55 @@ const gridLines = computed(() => {
       <div class="grid grid-cols-2 gap-3">
         <!-- Feels like -->
         <div
-          class="flex flex-col items-center gap-1 rounded-2xl border border-slate-200 dark:border-white/10 bg-white/50 dark:bg-white/10 px-2 py-3 text-center"
+          class="surface-inset flex flex-col items-center gap-1 rounded-[1.1rem] px-2 py-3 text-center"
         >
-          <svg class="size-5 text-slate-500 dark:text-white/60" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <svg class="size-5 text-storm-water-500 dark:text-sea-mist-300/70" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
             <path d="M14 14.76V3.5a2.5 2.5 0 0 0-5 0v11.26a4.5 4.5 0 1 0 5 0Z"/>
           </svg>
-          <span class="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-white/60">Feels like</span>
-          <span class="text-base font-semibold">{{ feelsLike }}°C</span>
+          <span class="text-xs font-medium uppercase tracking-[0.18em] text-storm-water-500 dark:text-sea-mist-300/65">Feels like</span>
+          <span class="text-base font-semibold text-storm-water-800 dark:text-dune-foam">{{ feelsLike }}°C</span>
         </div>
 
         <!-- Humidity -->
         <div
-          class="flex flex-col items-center gap-1 rounded-2xl border border-slate-200 dark:border-white/10 bg-white/50 dark:bg-white/10 px-2 py-3 text-center"
+          class="surface-inset flex flex-col items-center gap-1 rounded-[1.1rem] px-2 py-3 text-center"
         >
-          <svg class="size-5 text-slate-500 dark:text-white/60" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <svg class="size-5 text-storm-water-500 dark:text-sea-mist-300/70" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
             <path d="M12 2.69l5.66 5.66a8 8 0 1 1-11.31 0Z"/>
           </svg>
-          <span class="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-white/60">Humidity</span>
-          <span class="text-base font-semibold">{{ weather.humidity }}%</span>
+          <span class="text-xs font-medium uppercase tracking-[0.18em] text-storm-water-500 dark:text-sea-mist-300/65">Humidity</span>
+          <span class="text-base font-semibold text-storm-water-800 dark:text-dune-foam">{{ weather.humidity }}%</span>
         </div>
 
         <!-- Wind -->
         <div
-          class="flex flex-col items-center gap-1 rounded-2xl border border-slate-200 dark:border-white/10 bg-white/50 dark:bg-white/10 px-2 py-3 text-center"
+          class="surface-inset flex flex-col items-center gap-1 rounded-[1.1rem] px-2 py-3 text-center"
         >
-          <svg class="size-5 text-slate-500 dark:text-white/60" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <svg class="size-5 text-storm-water-500 dark:text-sea-mist-300/70" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
             <path d="M9.59 4.59A2 2 0 1 1 11 8H2m10.59 11.41A2 2 0 1 0 14 16H2m15.73-8.27A2.5 2.5 0 1 1 19.5 12H2"/>
           </svg>
-          <span class="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-white/60">Wind</span>
-          <span class="text-base font-semibold">
+          <span class="text-xs font-medium uppercase tracking-[0.18em] text-storm-water-500 dark:text-sea-mist-300/65">Wind</span>
+          <span class="text-base font-semibold text-storm-water-800 dark:text-dune-foam">
             {{ Math.round(weather.windSpeed) }}
-            <span class="text-xs font-normal text-slate-500 dark:text-white/70">km/h</span>
+            <span class="text-xs font-normal text-storm-water-500 dark:text-sea-mist-300/70">km/h</span>
           </span>
-          <span class="text-xs text-slate-500 dark:text-white/60">{{ windCompass }}</span>
+          <span class="text-xs text-storm-water-500 dark:text-sea-mist-300/65">{{ windCompass }}</span>
         </div>
 
         <!-- Moon phase -->
         <div
-          class="flex flex-col items-center gap-1 rounded-2xl border border-slate-200 dark:border-white/10 bg-white/50 dark:bg-white/10 px-2 py-3 text-center"
+          class="surface-inset flex flex-col items-center gap-1 rounded-[1.1rem] px-2 py-3 text-center"
         >
           <svg class="size-5 shrink-0" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" v-html="moonPhase.phaseIcon" />
-          <span class="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-white/60">Moon</span>
-          <span class="text-base font-semibold leading-tight">{{ moonPhase.phaseName }}</span>
+          <span class="text-xs font-medium uppercase tracking-[0.18em] text-storm-water-500 dark:text-sea-mist-300/65">Moon</span>
+          <span class="text-base font-semibold leading-tight text-storm-water-800 dark:text-dune-foam">{{ moonPhase.phaseName }}</span>
         </div>
       </div>
 
       <!-- Sunrise / Sunset tile -->
       <div
         v-if="todaySunrise || todaySunset"
-        class="mt-3 flex items-center justify-around rounded-2xl border border-slate-200 dark:border-white/10 bg-white/50 dark:bg-white/10 px-4 py-3"
+        class="surface-inset mt-3 flex items-center justify-around rounded-[1.1rem] px-4 py-3"
       >
         <!-- Sunrise -->
         <div class="flex items-center gap-2">
@@ -317,13 +318,13 @@ const gridLines = computed(() => {
             <line x1="2" y1="20" x2="22" y2="20"/>
           </svg>
           <div class="text-center">
-            <p class="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-white/60">Sunrise</p>
-            <p class="text-base font-semibold">{{ todaySunrise }}</p>
+            <p class="text-xs font-medium uppercase tracking-[0.18em] text-storm-water-500 dark:text-sea-mist-300/65">Sunrise</p>
+            <p class="text-base font-semibold text-storm-water-800 dark:text-dune-foam">{{ todaySunrise }}</p>
           </div>
         </div>
 
         <!-- Divider -->
-        <div class="h-8 w-px bg-slate-200 dark:bg-white/10" aria-hidden="true" />
+        <div class="h-8 w-px bg-slate-200 dark:bg-slate-600" aria-hidden="true" />
 
         <!-- Sunset -->
         <div class="flex items-center gap-2">
@@ -335,21 +336,21 @@ const gridLines = computed(() => {
             <path d="M12 6l-1.5 2h3L12 6z" fill="currentColor" stroke="none"/>
           </svg>
           <div class="text-center">
-            <p class="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-white/60">Sunset</p>
-            <p class="text-base font-semibold">{{ todaySunset }}</p>
+            <p class="text-xs font-medium uppercase tracking-[0.18em] text-storm-water-500 dark:text-sea-mist-300/65">Sunset</p>
+            <p class="text-base font-semibold text-storm-water-800 dark:text-dune-foam">{{ todaySunset }}</p>
           </div>
         </div>
       </div>
 
       <!-- Inline error when a refresh fails (but old weather data is still shown) -->
-      <p v-if="error" class="mt-3 text-center text-xs text-yellow-600 dark:text-yellow-300" role="alert">
+      <p v-if="error" class="mt-3 text-center text-xs text-[#7a5422] dark:text-[#e7c48b]" role="alert">
         ⚠️ Refresh failed — showing last known data
       </p>
 
       <!-- ---------------------------------------------------------------- -->
       <!-- Precipitation section                                              -->
       <!-- ---------------------------------------------------------------- -->
-      <hr class="my-4 border-slate-200 dark:border-white/10" />
+      <hr class="my-5 border atmospheric-rule" />
 
       <!-- Precipitation loading skeleton (weather card already visible) -->
       <template v-if="precipStore.loading && precipStore.entries.length === 0">
@@ -380,18 +381,18 @@ const gridLines = computed(() => {
               <div
                 v-for="line in gridLines"
                 :key="line.mmPerHour"
-                class="pointer-events-none absolute left-0 right-0 z-10"
-                :style="{ bottom: `${line.percent}%` }"
-              >
-                <div class="border-t border-dashed border-slate-300/40 dark:border-white/20" />
-              </div>
+                 class="pointer-events-none absolute left-0 right-0 z-10"
+                 :style="{ bottom: `${line.percent}%` }"
+               >
+                 <div class="border-t border-dashed border-storm-water-300/35 dark:border-white/10" />
+               </div>
 
               <!-- Bar columns -->
               <div class="flex h-full items-end gap-px">
               <div
                 v-for="(entry, idx) in precipStore.entries"
                 :key="entry.time"
-                class="relative flex-1 rounded-t transition-all duration-300"
+                 class="relative flex-1 rounded-t transition-all duration-300"
                 :class="barColorClass(entry.mmPerHour)"
                 :style="{ height: `${barHeightPercent(entry.mmPerHour)}%` }"
                 :title="`${entry.time} — ${entry.mmPerHour > 0 ? entry.mmPerHour.toFixed(2) + ' mm/h (' + (entry.mmPerHour < 0.5 ? 'drizzle' : entry.mmPerHour <= 2.5 ? 'light' : entry.mmPerHour <= 7.6 ? 'moderate' : 'heavy') + ')' : 'dry'}`"
@@ -411,7 +412,7 @@ const gridLines = computed(() => {
               <span
                 v-for="line in gridLines"
                 :key="'label-' + line.mmPerHour"
-                class="pointer-events-none absolute right-0 -translate-y-1/2 text-[9px] leading-none text-slate-400 dark:text-white/40"
+                 class="pointer-events-none absolute right-0 -translate-y-1/2 text-[9px] leading-none text-storm-water-400 dark:text-sea-mist-300/35"
                 :style="{ bottom: `${line.percent}%` }"
               >
                 {{ line.label }}
@@ -428,22 +429,22 @@ const gridLines = computed(() => {
             >
               <span
                 v-if="idx % labelInterval === 0"
-                class="text-[10px] leading-tight text-slate-600 dark:text-blue-200/60"
+                class="text-[10px] leading-tight text-storm-water-600 dark:text-sea-mist-200/60"
               >
                 {{ entry.time }}
               </span>
             </div>
-            <span class="shrink-0 text-[9px] leading-tight text-slate-400 dark:text-blue-200/40 pl-1">mm/h</span>
+            <span class="shrink-0 pl-1 text-[9px] leading-tight text-storm-water-400 dark:text-sea-mist-300/35">mm/h</span>
           </div>
         </div>
 
         <!-- Alert banner — tappable button to open radar -->
         <button
-          class="mt-4 w-full flex items-center gap-3 rounded-xl px-4 py-3 text-sm font-semibold shadow-inner transition-colors"
+          class="mt-5 flex w-full items-center gap-3 rounded-[1.1rem] border px-4 py-3 text-sm font-semibold transition-colors"
           :class="{
-            'bg-blue-500/70 text-white': alertStyle === 'rain',
-            'bg-yellow-400/80 text-yellow-900': alertStyle === 'soon',
-            'bg-green-500/60 text-white': alertStyle === 'clear',
+            'border-storm-water-700 bg-storm-water-700 text-dune-foam': alertStyle === 'rain',
+            'border-[#d1a56d] bg-[#efe1cd] text-[#352516] dark:bg-[#56422c] dark:text-[#f3dfbf]': alertStyle === 'soon',
+            'border-slate-300 bg-slate-50 text-storm-water-800 dark:border-slate-600 dark:bg-[#22313d] dark:text-dune-foam': alertStyle === 'clear',
           }"
           @click="$emit('open-radar')"
         >
@@ -504,7 +505,7 @@ const gridLines = computed(() => {
         </button>
 
         <!-- Non-blocking precipitation error notice -->
-        <p v-if="precipStore.error" class="mt-3 text-center text-xs text-yellow-600/80 dark:text-yellow-300/80">
+        <p v-if="precipStore.error" class="mt-3 text-center text-xs text-[#7a5422]/90 dark:text-[#e7c48b]/85">
           ⚠️ {{ precipStore.error }}
         </p>
       </template>

--- a/src/components/DailyForecast.vue
+++ b/src/components/DailyForecast.vue
@@ -173,7 +173,7 @@ const error = computed(() => weatherStore.error)
         <div class="w-16 shrink-0">
           <span
             class="block text-sm font-semibold"
-            :class="index === 0 ? 'font-display text-storm-water-800 dark:text-dune-foam' : 'text-storm-water-700 dark:text-sea-mist-100'"
+            :class="index === 0 ? 'text-storm-water-800 dark:text-dune-foam' : 'text-storm-water-700 dark:text-sea-mist-100'"
           >
             {{ day.dayName }}
           </span>
@@ -200,7 +200,7 @@ const error = computed(() => weatherStore.error)
 
         <!-- Temperature range (pushed to the right) -->
         <div class="ml-auto flex items-baseline gap-1 tabular-nums">
-          <span class="font-display text-base font-semibold text-storm-water-800 dark:text-dune-foam">{{ day.tempMax }}°</span>
+          <span class="text-base font-semibold text-storm-water-800 dark:text-dune-foam">{{ day.tempMax }}°</span>
           <span class="text-xs text-storm-water-400 dark:text-sea-mist-300/55">/ {{ day.tempMin }}°</span>
         </div>
       </div>

--- a/src/components/DailyForecast.vue
+++ b/src/components/DailyForecast.vue
@@ -4,7 +4,9 @@ import { useWeatherStore } from '@/stores/weather'
 import WeatherIcon from '@/components/WeatherIcon.vue'
 import type { WeatherIntensity } from '@/utils/weatherCodes'
 
-const weatherStore = useWeatherStore()
+  const weatherStore = useWeatherStore()
+
+const precipitationIcon = `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 2.69l5.66 5.66a8 8 0 1 1-11.31 0Z"/></svg>`
 
 /** Format an ISO date string (YYYY-MM-DD) to a short day name like "Mon". */
 function formatDayName(dateStr: string, index: number): string {
@@ -116,7 +118,7 @@ const error = computed(() => weatherStore.error)
   <!-- Loading skeleton -->
   <div
     v-if="isLoading"
-    class="w-full max-w-md overflow-hidden rounded-2xl border border-slate-300/50 dark:border-white/20 bg-slate-100 dark:bg-white/10 p-5 shadow-xl backdrop-blur-md"
+    class="surface-panel w-full max-w-md overflow-hidden p-5"
     aria-busy="true"
     aria-label="Loading 7-day forecast"
   >
@@ -132,7 +134,7 @@ const error = computed(() => weatherStore.error)
   <!-- Error state (no data at all) -->
   <div
     v-else-if="error && !days.length"
-    class="w-full max-w-md overflow-hidden rounded-2xl border border-red-400/30 bg-red-500/20 p-5 shadow-xl backdrop-blur-md"
+    class="w-full max-w-md overflow-hidden rounded-panel border border-[#a96f61]/30 bg-[#b97a6a]/18 p-5 shadow-mist backdrop-blur-xl dark:border-[#dca293]/20 dark:bg-[#7d4c42]/18 dark:shadow-storm"
     role="alert"
   >
     <div class="flex items-start gap-3">
@@ -147,16 +149,16 @@ const error = computed(() => weatherStore.error)
   <!-- Forecast card -->
   <div
     v-else-if="days.length"
-    class="w-full max-w-md overflow-hidden rounded-2xl border border-slate-300/50 dark:border-white/20 bg-gradient-to-br from-white/70 via-white/60 to-white/50 dark:from-slate-700/30 dark:via-slate-800/20 dark:to-slate-900/10 shadow-xl backdrop-blur-md transition-all duration-500"
+    class="surface-panel relative w-full max-w-md overflow-hidden transition-all duration-500"
   >
     <!-- Subtle loading bar when refreshing with existing data -->
     <div
       v-if="weatherStore.loading"
-      class="h-0.5 w-full animate-pulse bg-gradient-to-r from-transparent via-slate-400/60 dark:via-white/60 to-transparent"
+      class="relative z-10 h-0.5 w-full animate-pulse bg-gradient-to-r from-transparent via-storm-water-500/50 to-transparent dark:via-sea-mist-300/45"
     />
 
-    <div class="p-5">
-      <h2 class="mb-3 text-sm font-semibold uppercase tracking-widest text-slate-500 dark:text-white/60">
+    <div class="relative z-10 p-5">
+      <h2 class="mb-4 text-sm font-semibold uppercase tracking-[0.24em] text-storm-water-500 dark:text-sea-mist-300/65">
         7-Day Forecast
       </h2>
 
@@ -164,18 +166,18 @@ const error = computed(() => weatherStore.error)
       <div
         v-for="(day, index) in days"
         :key="day.date"
-        class="flex min-h-[44px] items-center gap-3 py-2"
-        :class="{ 'border-t border-slate-200 dark:border-white/10': index > 0 }"
+        class="surface-inset flex min-h-[52px] items-center gap-3 rounded-[1rem] px-3 py-3"
+        :class="index > 0 ? 'mt-2' : ''"
       >
         <!-- Day name + date -->
         <div class="w-16 shrink-0">
           <span
             class="block text-sm font-semibold"
-            :class="index === 0 ? '' : 'text-slate-600 dark:text-blue-100'"
+            :class="index === 0 ? 'font-display text-storm-water-800 dark:text-dune-foam' : 'text-storm-water-700 dark:text-sea-mist-100'"
           >
             {{ day.dayName }}
           </span>
-          <span class="block text-xs text-slate-400 dark:text-blue-300">{{ day.dateLabel }}</span>
+          <span class="block text-xs text-storm-water-400 dark:text-sea-mist-300/55">{{ day.dateLabel }}</span>
         </div>
 
         <!-- Weather icon -->
@@ -186,25 +188,25 @@ const error = computed(() => weatherStore.error)
         />
 
         <!-- Precipitation info -->
-        <div class="flex items-center gap-2 text-xs text-blue-600 dark:text-blue-200">
+        <div class="flex items-center gap-2 text-xs text-storm-water-600 dark:text-sea-mist-200">
           <span class="flex items-center gap-0.5">
-            <span aria-hidden="true">💧</span>
+            <span class="size-3.5" aria-hidden="true" v-html="precipitationIcon" />
             <span>{{ day.precipProb }}%</span>
           </span>
-          <span v-if="day.precipSum > 0" class="flex items-center gap-0.5 text-blue-500 dark:text-blue-300">
+          <span v-if="day.precipSum > 0" class="flex items-center gap-0.5 text-storm-water-500 dark:text-[#d7b07c]/82">
             <span>{{ day.precipSum }}mm</span>
           </span>
         </div>
 
         <!-- Temperature range (pushed to the right) -->
         <div class="ml-auto flex items-baseline gap-1 tabular-nums">
-          <span class="text-sm font-bold">{{ day.tempMax }}°</span>
-          <span class="text-xs text-slate-400 dark:text-blue-300">/ {{ day.tempMin }}°</span>
+          <span class="font-display text-base font-semibold text-storm-water-800 dark:text-dune-foam">{{ day.tempMax }}°</span>
+          <span class="text-xs text-storm-water-400 dark:text-sea-mist-300/55">/ {{ day.tempMin }}°</span>
         </div>
       </div>
 
       <!-- Inline error when a refresh fails but old data is shown -->
-      <p v-if="error" class="mt-3 text-center text-xs text-yellow-600 dark:text-yellow-300" role="alert">
+      <p v-if="error" class="mt-3 text-center text-xs text-[#7a5422] dark:text-[#e7c48b]" role="alert">
         ⚠️ Refresh failed — showing last known data
       </p>
     </div>

--- a/src/components/HourlyForecast.vue
+++ b/src/components/HourlyForecast.vue
@@ -114,7 +114,7 @@ const hourlyCards = computed<HourlyCard[]>(() => {
             :size="28"
           />
           <!-- Temperature -->
-          <span class="font-display text-base font-semibold text-storm-water-800 dark:text-dune-foam">{{ card.temp }}°</span>
+          <span class="text-base font-semibold text-storm-water-800 dark:text-dune-foam">{{ card.temp }}°</span>
           <!-- Precipitation mm (only if > 0) -->
           <span
             v-if="card.precip > 0"

--- a/src/components/HourlyForecast.vue
+++ b/src/components/HourlyForecast.vue
@@ -44,7 +44,7 @@ const hourlyCards = computed<HourlyCard[]>(() => {
   <!-- -------------------------------------------------------------------- -->
   <div
     v-if="loading && !forecast"
-    class="w-full max-w-md overflow-hidden rounded-3xl border border-slate-300/50 dark:border-white/20 bg-slate-100 dark:bg-white/10 shadow-2xl backdrop-blur-md"
+    class="surface-panel w-full max-w-md overflow-hidden"
     aria-busy="true"
     aria-label="Loading hourly forecast"
   >
@@ -66,7 +66,7 @@ const hourlyCards = computed<HourlyCard[]>(() => {
   <!-- -------------------------------------------------------------------- -->
   <div
     v-else-if="error && !forecast"
-    class="w-full max-w-md overflow-hidden rounded-3xl border border-red-400/30 bg-red-500/20 p-6 shadow-2xl backdrop-blur-md"
+    class="w-full max-w-md overflow-hidden rounded-panel border border-[#a96f61]/30 bg-[#b97a6a]/18 p-6 shadow-mist backdrop-blur-xl dark:border-[#dca293]/20 dark:bg-[#7d4c42]/18 dark:shadow-storm"
     role="alert"
   >
     <div class="flex items-start gap-3">
@@ -83,17 +83,17 @@ const hourlyCards = computed<HourlyCard[]>(() => {
   <!-- -------------------------------------------------------------------- -->
   <div
     v-else-if="forecast"
-    class="w-full max-w-md overflow-hidden rounded-3xl border border-slate-300/50 dark:border-white/20 bg-gradient-to-br from-white/70 via-white/60 to-white/50 dark:from-slate-700/40 dark:via-slate-800/30 dark:to-slate-900/20 shadow-2xl backdrop-blur-md transition-all duration-500"
+    class="surface-panel relative w-full max-w-md overflow-hidden transition-all duration-500"
   >
     <!-- Subtle loading bar when refreshing -->
     <div
       v-if="loading"
-      class="h-0.5 w-full animate-pulse bg-gradient-to-r from-transparent via-slate-400/60 dark:via-white/60 to-transparent"
+      class="relative z-10 h-0.5 w-full animate-pulse bg-gradient-to-r from-transparent via-storm-water-500/50 to-transparent dark:via-sea-mist-300/45"
     />
 
-    <div class="p-5">
+    <div class="relative z-10 p-5">
       <!-- Section title -->
-      <h2 class="mb-3 text-sm font-semibold uppercase tracking-widest text-slate-500 dark:text-white/60">
+      <h2 class="mb-4 text-sm font-semibold uppercase tracking-[0.24em] text-storm-water-500 dark:text-sea-mist-300/65">
         24-Hour Forecast
       </h2>
 
@@ -102,10 +102,10 @@ const hourlyCards = computed<HourlyCard[]>(() => {
         <div
           v-for="card in hourlyCards"
           :key="card.time"
-          class="flex-shrink-0 w-16 flex flex-col items-center gap-1 rounded-xl py-2 px-1 snap-start bg-slate-100/80 dark:bg-white/10"
+          class="surface-inset flex w-[4.5rem] flex-shrink-0 snap-start flex-col items-center gap-1.5 rounded-[1rem] px-1.5 py-2.5"
         >
           <!-- Time -->
-          <span class="text-xs text-slate-500 dark:text-white/60">{{ card.time }}</span>
+          <span class="text-[11px] uppercase tracking-[0.18em] text-storm-water-500 dark:text-sea-mist-300/65">{{ card.time }}</span>
           <!-- Weather icon -->
           <WeatherIcon
             :code="card.code"
@@ -114,19 +114,19 @@ const hourlyCards = computed<HourlyCard[]>(() => {
             :size="28"
           />
           <!-- Temperature -->
-          <span class="text-sm font-semibold text-slate-800 dark:text-white">{{ card.temp }}°</span>
+          <span class="font-display text-base font-semibold text-storm-water-800 dark:text-dune-foam">{{ card.temp }}°</span>
           <!-- Precipitation mm (only if > 0) -->
           <span
             v-if="card.precip > 0"
-            class="text-xs text-blue-500 dark:text-blue-300"
+            class="text-[11px] font-medium text-storm-water-600 dark:text-sea-mist-200/90"
           >{{ card.precip }}mm</span>
           <!-- Precipitation probability -->
-          <span class="text-[10px] text-slate-400 dark:text-blue-200/60">{{ card.precipProb }}%</span>
+          <span class="text-[10px] text-storm-water-400 dark:text-[#d7b07c]/70">{{ card.precipProb }}%</span>
         </div>
       </div>
 
       <!-- Inline error when refresh fails but old data is shown -->
-      <p v-if="error" class="mt-3 text-center text-xs text-yellow-600 dark:text-yellow-300" role="alert">
+      <p v-if="error" class="mt-3 text-center text-xs text-[#7a5422] dark:text-[#e7c48b]" role="alert">
         ⚠️ Refresh failed — showing last known data
       </p>
     </div>

--- a/src/components/LocationSearch.vue
+++ b/src/components/LocationSearch.vue
@@ -116,11 +116,11 @@ function getCitySubtitle(city: CitySearchResult): string {
   <div ref="containerRef" class="relative w-full max-w-md">
     <!-- Search input -->
     <div
-      class="flex items-center gap-2 rounded-xl border border-slate-300 bg-white/60 px-4 py-2.5 shadow-sm backdrop-blur-sm transition-all focus-within:border-blue-400 focus-within:bg-white/80 dark:border-white/20 dark:bg-white/10 dark:focus-within:border-white/60 dark:focus-within:bg-white/20"
+      class="flex items-center gap-3 rounded-[1.1rem] border border-slate-300 bg-white px-4 py-3 shadow-[0_8px_22px_rgba(36,48,57,0.05)] transition-all focus-within:border-storm-water-500 dark:border-slate-700 dark:bg-[#1b2731] dark:focus-within:border-sea-mist-300"
     >
       <!-- Magnifying glass icon -->
       <svg
-        class="size-5 shrink-0 text-blue-500 dark:text-blue-300"
+        class="size-5 shrink-0 text-storm-water-600 dark:text-sea-mist-300"
         xmlns="http://www.w3.org/2000/svg"
         fill="none"
         viewBox="0 0 24 24"
@@ -142,7 +142,7 @@ function getCitySubtitle(city: CitySearchResult): string {
         placeholder="Search a city…"
         autocomplete="off"
         spellcheck="false"
-        class="flex-1 bg-transparent text-sm text-slate-800 placeholder-slate-400 outline-none dark:text-white dark:placeholder-blue-300"
+        class="flex-1 bg-transparent text-sm text-storm-water-800 placeholder-storm-water-400 outline-none dark:text-dune-foam dark:placeholder-sea-mist-300/55"
         aria-label="Search for a city"
         aria-autocomplete="list"
         :aria-expanded="isOpen"
@@ -153,7 +153,7 @@ function getCitySubtitle(city: CitySearchResult): string {
       <!-- Loading spinner -->
       <svg
         v-if="isLoading"
-        class="size-4 shrink-0 animate-spin text-blue-500 dark:text-blue-200"
+        class="size-4 shrink-0 animate-spin text-storm-water-600 dark:text-sea-mist-200"
         xmlns="http://www.w3.org/2000/svg"
         fill="none"
         viewBox="0 0 24 24"
@@ -170,7 +170,7 @@ function getCitySubtitle(city: CitySearchResult): string {
       <!-- Clear button -->
       <button
         v-else-if="query"
-        class="shrink-0 text-slate-400 transition-colors hover:text-slate-800 dark:text-blue-200 dark:hover:text-white"
+        class="shrink-0 text-storm-water-400 transition-colors hover:text-storm-water-800 dark:text-sea-mist-300/70 dark:hover:text-white"
         aria-label="Clear search"
         @click="
           () => {
@@ -195,7 +195,7 @@ function getCitySubtitle(city: CitySearchResult): string {
     </div>
 
     <!-- Error message -->
-    <p v-if="errorMessage" class="mt-1.5 text-xs text-red-500 dark:text-red-300">
+    <p v-if="errorMessage" class="mt-2 text-xs text-[#8d4a3f] dark:text-[#efb4a7]">
       {{ errorMessage }}
     </p>
 
@@ -204,18 +204,18 @@ function getCitySubtitle(city: CitySearchResult): string {
       v-if="isOpen && results.length > 0"
       id="city-dropdown"
       role="listbox"
-      class="absolute z-50 mt-1.5 w-full overflow-hidden rounded-xl border border-slate-200 dark:border-white/20 bg-white/95 dark:bg-slate-800/95 shadow-xl backdrop-blur-md"
+      class="absolute z-50 mt-2 w-full overflow-hidden rounded-[1.1rem] border border-slate-300 bg-white shadow-[0_12px_28px_rgba(36,48,57,0.08)] dark:border-slate-700 dark:bg-[#1b2731]"
     >
       <li
         v-for="(city, index) in results"
         :key="`${city.name}-${city.latitude}-${city.longitude}`"
         role="option"
         :aria-selected="index === activeIndex"
-        class="flex cursor-pointer items-center gap-3 px-4 py-2.5 transition-colors"
+        class="flex cursor-pointer items-center gap-3 px-4 py-3 transition-colors"
         :class="
           index === activeIndex
-            ? 'bg-blue-600/80 text-white'
-            : 'text-slate-700 hover:bg-blue-100 dark:text-blue-100 dark:hover:bg-blue-700/60'
+            ? 'bg-storm-water-700 text-dune-foam'
+            : 'text-storm-water-700 hover:bg-slate-50 dark:text-sea-mist-100 dark:hover:bg-[#22313d]'
         "
         @mousedown.prevent="selectCity(city)"
         @mouseover="activeIndex = index"

--- a/src/components/RadarMap.vue
+++ b/src/components/RadarMap.vue
@@ -216,7 +216,7 @@ defineExpose({ openOverlay, nowcastStartIndex, isCurrentFrameNowcast })
             </span>
             <div>
               <p class="text-[11px] uppercase tracking-[0.24em] text-sea-mist-300/55">Live precipitation</p>
-              <h2 class="font-display text-lg text-dune-foam">Rain Radar</h2>
+              <h2 class="text-lg font-semibold text-dune-foam">Rain Radar</h2>
             </div>
           </div>
           <!-- Close button — min 44px tap target -->

--- a/src/components/RadarMap.vue
+++ b/src/components/RadarMap.vue
@@ -200,20 +200,28 @@ defineExpose({ openOverlay, nowcastStartIndex, isCurrentFrameNowcast })
     <Transition name="radar-overlay">
       <div
         v-if="isOpen"
-        class="fixed inset-0 z-50 flex flex-col bg-slate-900"
+        class="fixed inset-0 z-50 flex flex-col bg-[#17222b] text-dune-foam"
         role="dialog"
         aria-modal="true"
         aria-label="Rain Radar"
       >
         <!-- Top bar -->
-        <div class="flex shrink-0 items-center justify-between border-b border-white/10 px-5 py-3">
+        <div class="relative z-10 flex shrink-0 items-center justify-between border-b border-slate-700 bg-[#1b2731] px-5 py-3">
           <div class="flex items-center gap-2">
-            <span class="text-lg" aria-hidden="true">🌧️</span>
-            <h2 class="text-sm font-semibold uppercase tracking-wide text-white/80">Rain Radar</h2>
+            <span class="flex size-9 items-center justify-center rounded-full border border-slate-600 bg-[#22313d] text-sea-mist-100" aria-hidden="true">
+              <svg class="size-4.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M4 15.5A4.5 4.5 0 0 1 8.5 11H9a5 5 0 1 1 9.7 1.8A3.5 3.5 0 1 1 18 19H8a4 4 0 0 1-4-3.5Z" />
+                <path d="M9 18.5l1-2M13 18.5l1-2M17 18.5l1-2" />
+              </svg>
+            </span>
+            <div>
+              <p class="text-[11px] uppercase tracking-[0.24em] text-sea-mist-300/55">Live precipitation</p>
+              <h2 class="font-display text-lg text-dune-foam">Rain Radar</h2>
+            </div>
           </div>
           <!-- Close button — min 44px tap target -->
           <button
-            class="flex size-11 items-center justify-center rounded-full text-white/60 transition hover:bg-white/10 hover:text-white active:bg-white/20"
+            class="flex size-11 items-center justify-center rounded-full border border-slate-600 bg-[#22313d] text-sea-mist-200/70 transition hover:bg-[#2a3a47] hover:text-white active:bg-[#2a3a47]"
             aria-label="Close Rain Radar"
             @click="closeOverlay"
           >
@@ -242,7 +250,7 @@ defineExpose({ openOverlay, nowcastStartIndex, isCurrentFrameNowcast })
             aria-busy="true"
             aria-label="Loading radar map"
           >
-            <div class="flex flex-col items-center gap-3 text-blue-200/70">
+            <div class="flex flex-col items-center gap-3 text-sea-mist-200/75">
               <svg
                 class="size-8 animate-spin"
                 xmlns="http://www.w3.org/2000/svg"
@@ -267,11 +275,11 @@ defineExpose({ openOverlay, nowcastStartIndex, isCurrentFrameNowcast })
             class="flex h-full items-center justify-center px-6"
             role="alert"
           >
-            <div class="text-center text-sm text-yellow-300">
+            <div class="rounded-[1.1rem] border border-slate-700 bg-[#1b2731] px-5 py-4 text-center text-sm text-[#efcb9a]">
               <span class="mb-1 block text-2xl">⚠️</span>
               {{ error }}
               <button
-                class="mt-3 block w-full rounded-xl bg-white/10 px-4 py-2 text-xs font-medium text-white transition hover:bg-white/20"
+                class="mt-3 block w-full rounded-xl border border-slate-600 bg-[#22313d] px-4 py-2 text-xs font-medium text-dune-foam transition hover:bg-[#2a3a47]"
                 @click="loadFrames"
               >
                 Retry
@@ -310,7 +318,7 @@ defineExpose({ openOverlay, nowcastStartIndex, isCurrentFrameNowcast })
         </div>
 
         <!-- Animation controls -->
-        <div class="shrink-0 border-t border-white/10 bg-black/30 px-5 py-4 backdrop-blur-sm">
+        <div class="relative z-10 shrink-0 border-t border-slate-700 bg-[#1b2731] px-5 py-4">
           <!-- Timeline scrubber -->
           <div class="mb-3">
             <RadarScrubberB
@@ -327,7 +335,7 @@ defineExpose({ openOverlay, nowcastStartIndex, isCurrentFrameNowcast })
           <div class="flex items-center justify-center gap-4">
             <!-- Step back — 44px min tap target -->
             <button
-              class="flex size-11 items-center justify-center rounded-full bg-white/10 text-white/80 transition hover:bg-white/25 active:bg-white/30 disabled:opacity-30"
+              class="flex size-11 items-center justify-center rounded-full border border-slate-600 bg-[#22313d] text-sea-mist-100/85 transition hover:bg-[#2a3a47] active:bg-[#2a3a47] disabled:opacity-30"
               :disabled="currentFrameIndex === 0 || frames.length === 0"
               aria-label="Previous frame"
               @click="stepBack"
@@ -339,7 +347,7 @@ defineExpose({ openOverlay, nowcastStartIndex, isCurrentFrameNowcast })
 
             <!-- Play / Pause — 48px to make it the obvious CTA -->
             <button
-              class="flex size-12 items-center justify-center rounded-full bg-blue-500/70 text-white shadow-lg transition hover:bg-blue-500/90 active:bg-blue-500 disabled:opacity-40"
+              class="flex size-12 items-center justify-center rounded-full bg-[#d1a56d] text-[#1f160d] transition hover:brightness-105 active:brightness-95 disabled:opacity-40"
               :aria-label="isPlaying ? 'Pause animation' : 'Play animation'"
               :disabled="frames.length === 0"
               @click="togglePlay"
@@ -368,7 +376,7 @@ defineExpose({ openOverlay, nowcastStartIndex, isCurrentFrameNowcast })
 
             <!-- Step forward — 44px min tap target -->
             <button
-              class="flex size-11 items-center justify-center rounded-full bg-white/10 text-white/80 transition hover:bg-white/25 active:bg-white/30 disabled:opacity-30"
+              class="flex size-11 items-center justify-center rounded-full border border-slate-600 bg-[#22313d] text-sea-mist-100/85 transition hover:bg-[#2a3a47] active:bg-[#2a3a47] disabled:opacity-30"
               :disabled="currentFrameIndex === frameCount - 1 || frames.length === 0"
               aria-label="Next frame"
               @click="stepForward"
@@ -380,7 +388,7 @@ defineExpose({ openOverlay, nowcastStartIndex, isCurrentFrameNowcast })
           </div>
 
           <!-- Attribution note -->
-          <p class="mt-2 text-center text-[10px] text-blue-200/40">
+          <p class="mt-2 text-center text-[10px] tracking-[0.16em] text-sea-mist-300/35">
             Radar data by RainViewer
           </p>
         </div>

--- a/src/components/RadarScrubberB.vue
+++ b/src/components/RadarScrubberB.vue
@@ -197,22 +197,22 @@ function onPointerDown(event: PointerEvent): void {
       @pointerdown="onPointerDown"
     >
       <!-- ── Track ───────────────────────────────────────────────────── -->
-      <div class="relative h-1.5 w-full rounded-full bg-white/15">
+      <div class="relative h-1.5 w-full rounded-full bg-slate-700">
         <!-- Past fill (blue) -->
         <div
           v-if="currentFrameIndex < nowcastStartIndex || !hasNowcast"
-          class="absolute inset-y-0 left-0 rounded-full bg-blue-400"
+          class="absolute inset-y-0 left-0 rounded-full bg-[#7b95a5]"
           :style="{ width: `${filledWidth}%` }"
         />
 
         <!-- Forecast zone: full blue past + amber forecast portion -->
         <template v-else>
           <div
-            class="absolute inset-y-0 left-0 rounded-l-full bg-blue-400"
+            class="absolute inset-y-0 left-0 rounded-l-full bg-[#7b95a5]"
             :style="{ width: `${nowPosition}%` }"
           />
           <div
-            class="absolute inset-y-0 bg-amber-400"
+            class="absolute inset-y-0 bg-[#d4a261]"
             :style="{
               left: `${nowPosition}%`,
               width: `${filledWidth - nowPosition}%`,
@@ -223,7 +223,7 @@ function onPointerDown(event: PointerEvent): void {
         <!-- "Now" divider line on track -->
         <div
           v-if="frames.length > 0"
-          class="absolute top-1/2 z-10 h-3 w-0.5 -translate-y-1/2 rounded-full bg-white/80"
+          class="absolute top-1/2 z-10 h-3 w-0.5 -translate-y-1/2 rounded-full bg-dune-foam/75"
           :style="{ left: `${nowPosition}%` }"
         />
       </div>
@@ -235,8 +235,8 @@ function onPointerDown(event: PointerEvent): void {
       >
         <div class="flex size-[44px] items-center justify-center">
           <div
-            class="size-5 rounded-full ring-2 ring-white/80 transition-colors duration-150"
-            :class="isNowcast ? 'bg-amber-400' : 'bg-blue-400'"
+            class="size-5 rounded-full ring-2 ring-dune-foam/70 transition-colors duration-150"
+            :class="isNowcast ? 'bg-[#d4a261]' : 'bg-[#7192a4]'"
           />
         </div>
       </div>

--- a/src/composables/useMoonPhase.ts
+++ b/src/composables/useMoonPhase.ts
@@ -55,43 +55,82 @@ export function getMoonPhaseName(fraction: number): string {
 // ---------------------------------------------------------------------------
 // SVG moon phase icons (viewBox 0 0 64 64)
 // ---------------------------------------------------------------------------
-// All icons use a dark-circle base (#1E293B, slate-800) with a light disc
-// (#E2E8F0, slate-200) to show the illuminated portion. Works in both
-// light and dark mode.
+// These intentionally match the app's weather icon language: soft filled
+// shapes, no hard outline iconography, and the same night-sky palette.
+//
+// Palette used:
+//   - Moon light: #93C5FD (blue-300)
+//   - Moon bright: #E2E8F0 (slate-200)
+//   - Shadow: #334155 (slate-700)
+//   - Craters: #CBD5E1 (slate-300)
 
 const MOON_ICONS: Record<string, string> = {
   'New Moon': `
-    <circle cx="32" cy="32" r="22" fill="#1E293B" stroke="#475569" stroke-width="1.5"/>`,
+    <circle cx="32" cy="32" r="18" fill="#334155"/>
+    <circle cx="32" cy="32" r="18" fill="url(#moon-shadow-glow)" opacity="0.25"/>
+    <circle cx="47" cy="18" r="1.6" fill="#E2E8F0" opacity="0.8"/>
+    <circle cx="16" cy="22" r="1.2" fill="#E2E8F0" opacity="0.55"/>
+    <circle cx="50" cy="42" r="1" fill="#E2E8F0" opacity="0.45"/>
+    <defs>
+      <radialGradient id="moon-shadow-glow" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(30 26) rotate(50) scale(22)">
+        <stop stop-color="#64748B"/>
+        <stop offset="1" stop-color="#334155" stop-opacity="0"/>
+      </radialGradient>
+    </defs>`,
 
   'Waxing Crescent': `
-    <circle cx="32" cy="32" r="22" fill="#1E293B" stroke="#475569" stroke-width="1.5"/>
-    <path d="M32 10 Q50 18 50 32 Q50 46 32 54 Q42 46 42 32 Q42 18 32 10 Z" fill="#E2E8F0"/>`,
+    <circle cx="32" cy="32" r="18" fill="#334155"/>
+    <path d="M32 14 C42 18 46 25 46 32 C46 39 42 46 32 50 C38 44 40 38 40 32 C40 26 38 20 32 14 Z" fill="#93C5FD"/>
+    <path d="M35 18 C42 22 45 27 45 32 C45 37 42 42 35 46 C39 41 40.5 37 40.5 32 C40.5 27 39 23 35 18 Z" fill="#E2E8F0" opacity="0.55"/>
+    <circle cx="47" cy="18" r="1.6" fill="#E2E8F0" opacity="0.8"/>
+    <circle cx="16" cy="22" r="1.2" fill="#E2E8F0" opacity="0.55"/>
+    <path d="M14 44l0.8 1.8L16.6 46l-1.8 0.8-0.8 1.8-0.8-1.8L11.4 46l1.8-0.2Z" fill="#E2E8F0" opacity="0.45"/>`,
 
   'First Quarter': `
-    <circle cx="32" cy="32" r="22" fill="#1E293B" stroke="#475569" stroke-width="1.5"/>
-    <path d="M32 10 Q54 10 54 32 Q54 54 32 54 Z" fill="#E2E8F0"/>`,
+    <circle cx="32" cy="32" r="18" fill="#334155"/>
+    <path d="M32 14 A18 18 0 0 1 32 50 Z" fill="#93C5FD"/>
+    <path d="M32 18 A14 14 0 0 1 32 46 Z" fill="#E2E8F0" opacity="0.38"/>`,
 
   'Waxing Gibbous': `
-    <circle cx="32" cy="32" r="22" fill="#E2E8F0"/>
-    <path d="M32 10 Q14 18 14 32 Q14 46 32 54 Q22 46 22 32 Q22 18 32 10 Z" fill="#1E293B"/>`,
+    <circle cx="32" cy="32" r="18" fill="#93C5FD"/>
+    <path d="M32 14 C24 18 20 25 20 32 C20 39 24 46 32 50 C26 44 26 38 26 32 C26 26 26 20 32 14 Z" fill="#334155"/>
+    <circle cx="38" cy="26" r="2.1" fill="#E2E8F0" opacity="0.35"/>
+    <circle cx="40.5" cy="34.5" r="1.4" fill="#E2E8F0" opacity="0.28"/>
+    <circle cx="33.5" cy="39" r="1.8" fill="#CBD5E1" opacity="0.22"/>`,
 
   'Full Moon': `
-    <circle cx="32" cy="32" r="22" fill="#E2E8F0" stroke="#CBD5E1" stroke-width="1"/>
-    <circle cx="26" cy="28" r="3" fill="#CBD5E1" opacity="0.5"/>
-    <circle cx="38" cy="36" r="4" fill="#CBD5E1" opacity="0.4"/>
-    <circle cx="30" cy="38" r="2" fill="#CBD5E1" opacity="0.35"/>`,
+    <circle cx="32" cy="32" r="18" fill="#93C5FD"/>
+    <circle cx="32" cy="32" r="18" fill="url(#moon-full-glow)" opacity="0.25"/>
+    <circle cx="27" cy="28" r="2.3" fill="#CBD5E1" opacity="0.45"/>
+    <circle cx="38" cy="35" r="2.8" fill="#CBD5E1" opacity="0.35"/>
+    <circle cx="31" cy="39" r="1.7" fill="#CBD5E1" opacity="0.25"/>
+    <circle cx="35" cy="23.5" r="1.2" fill="#E2E8F0" opacity="0.28"/>
+    <defs>
+      <radialGradient id="moon-full-glow" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(28 24) rotate(50) scale(22)">
+        <stop stop-color="#E2E8F0"/>
+        <stop offset="1" stop-color="#93C5FD" stop-opacity="0"/>
+      </radialGradient>
+    </defs>`,
 
   'Waning Gibbous': `
-    <circle cx="32" cy="32" r="22" fill="#E2E8F0"/>
-    <path d="M32 10 Q50 18 50 32 Q50 46 32 54 Q42 46 42 32 Q42 18 32 10 Z" fill="#1E293B"/>`,
+    <circle cx="32" cy="32" r="18" fill="#93C5FD"/>
+    <path d="M32 14 C40 18 44 25 44 32 C44 39 40 46 32 50 C38 44 38 38 38 32 C38 26 38 20 32 14 Z" fill="#334155"/>
+    <circle cx="26" cy="26" r="2.1" fill="#E2E8F0" opacity="0.35"/>
+    <circle cx="23.5" cy="34.5" r="1.4" fill="#E2E8F0" opacity="0.28"/>
+    <circle cx="30.5" cy="39" r="1.8" fill="#CBD5E1" opacity="0.22"/>`,
 
   'Last Quarter': `
-    <circle cx="32" cy="32" r="22" fill="#1E293B" stroke="#475569" stroke-width="1.5"/>
-    <path d="M32 10 Q10 10 10 32 Q10 54 32 54 Z" fill="#E2E8F0"/>`,
+    <circle cx="32" cy="32" r="18" fill="#334155"/>
+    <path d="M32 14 A18 18 0 0 0 32 50 Z" fill="#93C5FD"/>
+    <path d="M32 18 A14 14 0 0 0 32 46 Z" fill="#E2E8F0" opacity="0.38"/>`,
 
   'Waning Crescent': `
-    <circle cx="32" cy="32" r="22" fill="#1E293B" stroke="#475569" stroke-width="1.5"/>
-    <path d="M32 10 Q14 18 14 32 Q14 46 32 54 Q22 46 22 32 Q22 18 32 10 Z" fill="#E2E8F0"/>`,
+    <circle cx="32" cy="32" r="18" fill="#334155"/>
+    <path d="M32 14 C22 18 18 25 18 32 C18 39 22 46 32 50 C26 44 24 38 24 32 C24 26 26 20 32 14 Z" fill="#93C5FD"/>
+    <path d="M29 18 C22 22 19 27 19 32 C19 37 22 42 29 46 C25 41 23.5 37 23.5 32 C23.5 27 25 23 29 18 Z" fill="#E2E8F0" opacity="0.55"/>
+    <circle cx="47" cy="18" r="1.6" fill="#E2E8F0" opacity="0.8"/>
+    <circle cx="16" cy="22" r="1.2" fill="#E2E8F0" opacity="0.55"/>
+    <path d="M50 44l0.8 1.8L53.6 46l-1.8 0.8-0.8 1.8-0.8-1.8L47.4 46l1.8-0.2Z" fill="#E2E8F0" opacity="0.45"/>`,
 }
 
 export function getMoonPhaseIcon(phaseName: string): string {

--- a/src/composables/useMoonPhase.ts
+++ b/src/composables/useMoonPhase.ts
@@ -68,6 +68,7 @@ const MOON_ICONS: Record<string, string> = {
   'New Moon': `
     <circle cx="32" cy="32" r="18" fill="#334155"/>
     <circle cx="32" cy="32" r="18" fill="url(#moon-shadow-glow)" opacity="0.25"/>
+    <path d="M22 48 Q32 43 42 48" stroke="#475569" stroke-width="1.6" stroke-linecap="round" opacity="0.45"/>
     <circle cx="47" cy="18" r="1.6" fill="#E2E8F0" opacity="0.8"/>
     <circle cx="16" cy="22" r="1.2" fill="#E2E8F0" opacity="0.55"/>
     <circle cx="50" cy="42" r="1" fill="#E2E8F0" opacity="0.45"/>
@@ -82,6 +83,8 @@ const MOON_ICONS: Record<string, string> = {
     <circle cx="32" cy="32" r="18" fill="#334155"/>
     <path d="M32 14 C42 18 46 25 46 32 C46 39 42 46 32 50 C38 44 40 38 40 32 C40 26 38 20 32 14 Z" fill="#93C5FD"/>
     <path d="M35 18 C42 22 45 27 45 32 C45 37 42 42 35 46 C39 41 40.5 37 40.5 32 C40.5 27 39 23 35 18 Z" fill="#E2E8F0" opacity="0.55"/>
+    <circle cx="37.5" cy="27.5" r="1.5" fill="#CBD5E1" opacity="0.18"/>
+    <circle cx="39.5" cy="36" r="1" fill="#CBD5E1" opacity="0.16"/>
     <circle cx="47" cy="18" r="1.6" fill="#E2E8F0" opacity="0.8"/>
     <circle cx="16" cy="22" r="1.2" fill="#E2E8F0" opacity="0.55"/>
     <path d="M14 44l0.8 1.8L16.6 46l-1.8 0.8-0.8 1.8-0.8-1.8L11.4 46l1.8-0.2Z" fill="#E2E8F0" opacity="0.45"/>`,
@@ -89,11 +92,14 @@ const MOON_ICONS: Record<string, string> = {
   'First Quarter': `
     <circle cx="32" cy="32" r="18" fill="#334155"/>
     <path d="M32 14 A18 18 0 0 1 32 50 Z" fill="#93C5FD"/>
-    <path d="M32 18 A14 14 0 0 1 32 46 Z" fill="#E2E8F0" opacity="0.38"/>`,
+    <path d="M32 18 A14 14 0 0 1 32 46 Z" fill="#E2E8F0" opacity="0.38"/>
+    <circle cx="37.5" cy="26.5" r="2" fill="#CBD5E1" opacity="0.24"/>
+    <circle cx="39.5" cy="36.5" r="1.2" fill="#CBD5E1" opacity="0.18"/>`,
 
   'Waxing Gibbous': `
     <circle cx="32" cy="32" r="18" fill="#93C5FD"/>
     <path d="M32 14 C24 18 20 25 20 32 C20 39 24 46 32 50 C26 44 26 38 26 32 C26 26 26 20 32 14 Z" fill="#334155"/>
+    <path d="M35 16 C42 20 45 26 45 32 C45 38 42 44 35 48" stroke="#E2E8F0" stroke-width="1.3" stroke-linecap="round" opacity="0.28"/>
     <circle cx="38" cy="26" r="2.1" fill="#E2E8F0" opacity="0.35"/>
     <circle cx="40.5" cy="34.5" r="1.4" fill="#E2E8F0" opacity="0.28"/>
     <circle cx="33.5" cy="39" r="1.8" fill="#CBD5E1" opacity="0.22"/>`,
@@ -101,10 +107,12 @@ const MOON_ICONS: Record<string, string> = {
   'Full Moon': `
     <circle cx="32" cy="32" r="18" fill="#93C5FD"/>
     <circle cx="32" cy="32" r="18" fill="url(#moon-full-glow)" opacity="0.25"/>
+    <path d="M20 24 Q32 18 44 24" stroke="#E2E8F0" stroke-width="1.2" stroke-linecap="round" opacity="0.22"/>
     <circle cx="27" cy="28" r="2.3" fill="#CBD5E1" opacity="0.45"/>
     <circle cx="38" cy="35" r="2.8" fill="#CBD5E1" opacity="0.35"/>
     <circle cx="31" cy="39" r="1.7" fill="#CBD5E1" opacity="0.25"/>
     <circle cx="35" cy="23.5" r="1.2" fill="#E2E8F0" opacity="0.28"/>
+    <circle cx="24.5" cy="34.5" r="1.1" fill="#E2E8F0" opacity="0.18"/>
     <defs>
       <radialGradient id="moon-full-glow" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(28 24) rotate(50) scale(22)">
         <stop stop-color="#E2E8F0"/>
@@ -115,6 +123,7 @@ const MOON_ICONS: Record<string, string> = {
   'Waning Gibbous': `
     <circle cx="32" cy="32" r="18" fill="#93C5FD"/>
     <path d="M32 14 C40 18 44 25 44 32 C44 39 40 46 32 50 C38 44 38 38 38 32 C38 26 38 20 32 14 Z" fill="#334155"/>
+    <path d="M29 16 C22 20 19 26 19 32 C19 38 22 44 29 48" stroke="#E2E8F0" stroke-width="1.3" stroke-linecap="round" opacity="0.28"/>
     <circle cx="26" cy="26" r="2.1" fill="#E2E8F0" opacity="0.35"/>
     <circle cx="23.5" cy="34.5" r="1.4" fill="#E2E8F0" opacity="0.28"/>
     <circle cx="30.5" cy="39" r="1.8" fill="#CBD5E1" opacity="0.22"/>`,
@@ -122,12 +131,16 @@ const MOON_ICONS: Record<string, string> = {
   'Last Quarter': `
     <circle cx="32" cy="32" r="18" fill="#334155"/>
     <path d="M32 14 A18 18 0 0 0 32 50 Z" fill="#93C5FD"/>
-    <path d="M32 18 A14 14 0 0 0 32 46 Z" fill="#E2E8F0" opacity="0.38"/>`,
+    <path d="M32 18 A14 14 0 0 0 32 46 Z" fill="#E2E8F0" opacity="0.38"/>
+    <circle cx="26.5" cy="26.5" r="2" fill="#CBD5E1" opacity="0.24"/>
+    <circle cx="24.5" cy="36.5" r="1.2" fill="#CBD5E1" opacity="0.18"/>`,
 
   'Waning Crescent': `
     <circle cx="32" cy="32" r="18" fill="#334155"/>
     <path d="M32 14 C22 18 18 25 18 32 C18 39 22 46 32 50 C26 44 24 38 24 32 C24 26 26 20 32 14 Z" fill="#93C5FD"/>
     <path d="M29 18 C22 22 19 27 19 32 C19 37 22 42 29 46 C25 41 23.5 37 23.5 32 C23.5 27 25 23 29 18 Z" fill="#E2E8F0" opacity="0.55"/>
+    <circle cx="26.5" cy="27.5" r="1.5" fill="#CBD5E1" opacity="0.18"/>
+    <circle cx="24.5" cy="36" r="1" fill="#CBD5E1" opacity="0.16"/>
     <circle cx="47" cy="18" r="1.6" fill="#E2E8F0" opacity="0.8"/>
     <circle cx="16" cy="22" r="1.2" fill="#E2E8F0" opacity="0.55"/>
     <path d="M50 44l0.8 1.8L53.6 46l-1.8 0.8-0.8 1.8-0.8-1.8L47.4 46l1.8-0.2Z" fill="#E2E8F0" opacity="0.45"/>`,

--- a/src/style.css
+++ b/src/style.css
@@ -15,12 +15,11 @@
     -webkit-overflow-scrolling: touch;
     scroll-behavior: smooth;
     /* Safari website tinting samples html, not body */
-    /* Light mode default */
-    background-color: #bae6fd;
+    background-color: #eef3f6;
   }
 
   html.dark {
-    background-color: #0f2027;
+    background-color: #17222b;
   }
 
   body {
@@ -28,29 +27,37 @@
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
     text-rendering: optimizeLegibility;
+    font-family: Manrope, ui-sans-serif, system-ui, sans-serif;
 
-    /* Light mode default: soft daylight sky gradient */
-    background-color: #bae6fd;
+    background-color: #eef3f6;
     background: linear-gradient(
-      to bottom,
-      #bae6fd 0%,   /* sky-200 */
-      #e0f2fe 35%,  /* sky-100 */
-      #f0f9ff 70%,  /* sky-50 */
-      #f8fafc 100%  /* slate-50 */
+      180deg,
+      #f4f7f8 0%,
+      #eef3f6 28%,
+      #e6edf1 100%
     );
     min-height: 100dvh;
     overflow-x: clip;
+    color: #223443;
   }
 
-  /* Dark mode: deep night-sky gradient */
   html.dark body {
-    background-color: #0f2027;
+    background-color: #17222b;
     background: linear-gradient(
-      to bottom,
-      #0f2027 0%,
-      #1a3a5c 40%,
-      #1e3a8a 100%
+      180deg,
+      #1b2933 0%,
+      #17222b 45%,
+      #121920 100%
     );
+    color: #f2f5f7;
+  }
+
+  h1,
+  h2,
+  h3,
+  [data-display='true'] {
+    font-family: Fraunces, Georgia, serif;
+    font-feature-settings: 'ss01' 1;
   }
 }
 
@@ -84,6 +91,22 @@
 
 /* ── Safe-area utility ────────────────────────────────────────────────────── */
 @layer utilities {
+  .surface-hero {
+    @apply rounded-3xl border border-slate-300/80 bg-white shadow-[0_12px_34px_rgba(36,48,57,0.08)] dark:border-slate-700 dark:bg-[#1b2731] dark:shadow-[0_16px_40px_rgba(0,0,0,0.22)];
+  }
+
+  .surface-panel {
+    @apply rounded-[1.4rem] border border-slate-300/75 bg-white shadow-[0_10px_26px_rgba(36,48,57,0.06)] dark:border-slate-700 dark:bg-[#1b2731] dark:shadow-[0_14px_34px_rgba(0,0,0,0.18)];
+  }
+
+  .surface-inset {
+    @apply border border-slate-200 bg-slate-50 dark:border-slate-700 dark:bg-[#22313d];
+  }
+
+  .atmospheric-rule {
+    @apply border-slate-200 dark:border-slate-700;
+  }
+
   .pb-safe {
     padding-bottom: max(1.5rem, env(safe-area-inset-bottom));
   }

--- a/src/style.css
+++ b/src/style.css
@@ -52,9 +52,6 @@
     color: #f2f5f7;
   }
 
-  h1,
-  h2,
-  h3,
   [data-display='true'] {
     font-family: Fraunces, Georgia, serif;
     font-feature-settings: 'ss01' 1;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -7,6 +7,10 @@ export default {
   darkMode: 'class',
   theme: {
     extend: {
+      fontFamily: {
+        display: ['Fraunces', 'Georgia', 'serif'],
+        sans: ['Manrope', 'ui-sans-serif', 'system-ui', 'sans-serif'],
+      },
       colors: {
         'dutch-blue': {
           50: '#eff6ff',
@@ -28,12 +32,59 @@ export default {
           storm:  '#1e3a8a',
           clear:  '#fbbf24',
         },
+        'sea-mist': {
+          50: '#f4f8fb',
+          100: '#e8f0f5',
+          200: '#d4e1ea',
+          300: '#aec4d3',
+          400: '#7f9faf',
+          500: '#617f90',
+          600: '#4c6676',
+          700: '#3e5361',
+          800: '#31414c',
+          900: '#243039',
+        },
+        horizon: {
+          50: '#f6fbff',
+          100: '#edf6ff',
+          200: '#d9ebfb',
+          300: '#b7d8f0',
+          400: '#8fc0e1',
+          500: '#669fc4',
+          600: '#4e7ea1',
+          700: '#406481',
+          800: '#365169',
+          900: '#2d4357',
+        },
+        'storm-water': {
+          50: '#edf3f7',
+          100: '#d7e4ec',
+          200: '#b1cad8',
+          300: '#7fa7bb',
+          400: '#58839b',
+          500: '#40657c',
+          600: '#315165',
+          700: '#294252',
+          800: '#223443',
+          900: '#1b2a36',
+        },
+        'deep-current': '#14232d',
+        'dune-foam': '#f6f1e7',
+        'sun-glow': '#d8a55a',
       },
       spacing: {
         safe: 'env(safe-area-inset-bottom)',
       },
       screens: {
         xs: '390px',
+      },
+      borderRadius: {
+        hero: '2rem',
+        panel: '1.5rem',
+      },
+      boxShadow: {
+        mist: '0 18px 50px rgba(31, 58, 74, 0.14)',
+        storm: '0 22px 60px rgba(9, 20, 28, 0.34)',
       },
     }
   },


### PR DESCRIPTION
## Summary
- restyle the app shell and forecast surfaces with a cleaner editorial UI treatment
- redesign the current conditions card into a stronger day-overview hero with better use of daily context
- refine moon phase artwork, typography, and supporting weather details for a more cohesive visual system

## What changed
- updated the global UI treatment across `src/style.css`, `src/App.vue`, `src/components/HourlyForecast.vue`, `src/components/DailyForecast.vue`, `src/components/LocationSearch.vue`, and `src/components/RadarMap.vue`
- rebuilt `src/components/CurrentWeather.vue` so the hero now combines current temperature, day outlook, larger icon treatment, and richer supporting detail inside the stat tiles
- enriched `src/composables/useMoonPhase.ts` with more detailed moon phase artwork and aligned its presentation with the rest of the UI
- simplified typography usage so the display font is reserved for the hero temperature instead of being mixed throughout the interface

## Verification
- `npx vue-tsc --noEmit`
- `~/.bun/bin/bun run build`