### PR TITLE
feat: automatically check for PWA updates when returning to foreground

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -72,6 +72,7 @@ function refreshIfStale(): void {
 function onVisibilityChange(): void {
   if (document.visibilityState === 'visible') {
     refreshIfStale()
+    if (updateServiceWorker) { void updateServiceWorker(true) }
   }
 }
 


### PR DESCRIPTION
## Summary
When the user returns to the app (bringing it back from the background), the application will now actively ping the Service Worker to check if a new version is available, triggering the update banner to appear automatically if there is one.